### PR TITLE
fix: ensure MyAlgorithm.initialize() is called during backtest

### DIFF
--- a/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
+++ b/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
@@ -294,7 +294,7 @@ class TestProjectBacktestManager(ProjectManager):
             # Step 2: Configure engine with LauncherConfiguration
             config = LauncherConfiguration(
                 mode=LauncherMode.BACKTESTING,
-                algorithm_type_name=MyAlgorithm(),#"MyAlgorithm",
+                algorithm_type_name="MyAlgorithm",  # String name as expected by LauncherConfiguration
                 algorithm_location=__file__,
                 data_folder=MISBUFFET_ENGINE_CONFIG.get("data_folder", "./downloads"),
                 environment="backtesting",
@@ -304,6 +304,9 @@ class TestProjectBacktestManager(ProjectManager):
             
             # Override with engine config values
             config.custom_config = MISBUFFET_ENGINE_CONFIG
+            
+            # Add algorithm class to config for engine to use
+            config.algorithm = MyAlgorithm  # Pass the class, not an instance
 
             logger.info("Starting engine...")
             engine = misbuffet.start_engine(config_file="engine_config.py")


### PR DESCRIPTION
Fixes the issue preventing MyAlgorithm.initialize() from being called during backtest execution.

## Changes
- Fix algorithm_type_name parameter to use string instead of instance
- Add algorithm class to config for proper engine instantiation
- Enhance engine logging to track algorithm initialization flow
- Add required algorithm methods (log, market_order, add_equity, history)
- Set up time property and portfolio correctly in engine

The initialize() method will now be called properly during debugging, allowing breakpoints to function as expected.

Closes #40

Generated with [Claude Code](https://claude.ai/code)