### PR TITLE
fix: add algorithm property setter to BaseEngine

### DIFF
--- a/src/application/services/misbuffet/engine/base_engine.py
+++ b/src/application/services/misbuffet/engine/base_engine.py
@@ -70,6 +70,11 @@ class BaseEngine(IEngine, ABC):
         """Get the current algorithm instance."""
         return self._algorithm
     
+    @algorithm.setter
+    def algorithm(self, value: Optional[IAlgorithm]) -> None:
+        """Set the current algorithm instance."""
+        self._algorithm = value
+    
     @property
     def job(self) -> Optional[EngineNodePacket]:
         """Get the current job configuration."""


### PR DESCRIPTION
Resolves AttributeError in MisbuffetEngine initialization

The issue was that the `algorithm` property in `BaseEngine` only had a getter, but `MisbuffetEngine` tried to assign to it during initialization.

- Add missing setter for algorithm property in BaseEngine class
- Resolves AttributeError: property 'algorithm' of 'MisbuffetEngine' object has no setter
- Enables MisbuffetEngine to properly initialize algorithm property during __init__
- Maintains backward compatibility with existing code

Closes #47

Generated with [Claude Code](https://claude.ai/code)