### PR TITLE
fix: provide required arguments to EngineNodePacket constructor

### DIFF
--- a/src/application/services/misbuffet/engine/misbuffet_engine.py
+++ b/src/application/services/misbuffet/engine/misbuffet_engine.py
@@ -61,10 +61,15 @@ class MisbuffetEngine(BaseEngine):
         # Create a simple EngineNodePacket from config for BaseEngine compatibility
         try:
             from .engine_node_packet import EngineNodePacket
-            from .enums import EngineMode, LogLevel
+            from .enums import EngineMode, LogLevel, PacketType
             
-            # Create job packet from config
-            job = EngineNodePacket()
+            # Create job packet from config with required arguments
+            job = EngineNodePacket(
+                type=PacketType.ALGORITHM_NODE_PACKET,
+                user_id=1,  # Default user ID
+                project_id=1,  # Default project ID
+                session_id="misbuffet_session"  # Default session ID
+            )
             job.algorithm_id = getattr(config, 'algorithm_type_name', 'MisbuffetAlgorithm')
             job.engine_mode = EngineMode.BACKTESTING
             job.log_level = LogLevel.INFO


### PR DESCRIPTION
Resolves TypeError by providing the 4 required positional arguments to EngineNodePacket constructor:

- type: PacketType.ALGORITHM_NODE_PACKET
- user_id: 1 (default)
- project_id: 1 (default)
- session_id: 'misbuffet_session' (default)

This fixes the error: EngineNodePacket.__init__() missing 4 required positional arguments: 'type', 'user_id', 'project_id', and 'session_id'

Closes #47

Generated with [Claude Code](https://claude.ai/code)