### PR TITLE
Fix SQLAlchemy table redefinition error for MarketDataModel

### DIFF
--- a/src/infrastructure/models/finance/__init__.py
+++ b/src/infrastructure/models/finance/__init__.py
@@ -1,0 +1,19 @@
+"""
+Finance-related infrastructure models.
+Contains SQLAlchemy ORM models for financial entities.
+"""
+
+from src.infrastructure.models.finance.portfolio import Portfolio
+from src.infrastructure.models.finance.portfolio_holdings import (
+    PortfolioHoldingsModel, SecurityHoldingsModel
+)
+from src.infrastructure.models.finance.portfolio_statistics import PortfolioStatisticsModel
+from src.infrastructure.models.finance.market_data import MarketDataModel
+
+__all__ = [
+    'Portfolio',
+    'PortfolioHoldingsModel', 
+    'SecurityHoldingsModel',
+    'PortfolioStatisticsModel',
+    'MarketDataModel'
+]

--- a/src/infrastructure/models/finance/financial_assets/security.py
+++ b/src/infrastructure/models/finance/financial_assets/security.py
@@ -15,6 +15,7 @@ class Security(Base):
     Represents both live and mock/backtest securities with optional price snapshots.
     """
     __tablename__ = "securities"
+    __table_args__ = {'extend_existing': True}
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     portfolio_id = Column(Integer, ForeignKey("portfolios.id"), nullable=True)

--- a/src/infrastructure/models/finance/market_data.py
+++ b/src/infrastructure/models/finance/market_data.py
@@ -16,6 +16,7 @@ class MarketDataModel(Base):
     Stores comprehensive market data with OHLCV information.
     """
     __tablename__ = "market_data"
+    __table_args__ = {'extend_existing': True}
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     

--- a/src/infrastructure/models/finance/portfolio_holdings.py
+++ b/src/infrastructure/models/finance/portfolio_holdings.py
@@ -16,6 +16,7 @@ class PortfolioHoldingsModel(Base):
     Represents current holdings snapshot for a portfolio.
     """
     __tablename__ = "portfolio_holdings"
+    __table_args__ = {'extend_existing': True}
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     portfolio_id = Column(Integer, ForeignKey("portfolios.id"), nullable=False, index=True)
@@ -49,6 +50,7 @@ class SecurityHoldingsModel(Base):
     Represents holdings for a specific security.
     """
     __tablename__ = "security_holdings"
+    __table_args__ = {'extend_existing': True}
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     portfolio_id = Column(Integer, ForeignKey("portfolios.id"), nullable=False, index=True)

--- a/src/infrastructure/models/finance/portfolio_statistics.py
+++ b/src/infrastructure/models/finance/portfolio_statistics.py
@@ -16,6 +16,7 @@ class PortfolioStatisticsModel(Base):
     Stores performance and risk metrics for a portfolio.
     """
     __tablename__ = "portfolio_statistics"
+    __table_args__ = {'extend_existing': True}
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     portfolio_id = Column(Integer, ForeignKey("portfolios.id"), nullable=False, index=True)


### PR DESCRIPTION
**Fixed SQLAlchemy InvalidRequestError for table redefinition**

Resolved the error: `Table 'market_data' is already defined for this MetaData instance`

## Changes
- Added `extend_existing=True` to MarketDataModel, PortfolioHoldingsModel, SecurityHoldingsModel, PortfolioStatisticsModel, and Security models
- Created `__init__.py` for finance models directory to organize imports properly
- Prevents table redefinition conflicts when models are imported multiple times

## Benefits
- Eliminates SQLAlchemy InvalidRequestError
- Maintains full model functionality
- More robust against import conflicts
- Better organized model imports

Resolves issue #52

🤖 Generated with [Claude Code](https://claude.ai/code)