### PR TITLE
Fix SQLAlchemy Portfolio table redefinition error

### DIFF
--- a/src/infrastructure/models/finance/portfolio.py
+++ b/src/infrastructure/models/finance/portfolio.py
@@ -15,6 +15,7 @@ class Portfolio(Base):
     Represents both live portfolios and backtest/mock portfolios with snapshots.
     """
     __tablename__ = "portfolios"
+    __table_args__ = {'extend_existing': True}
 
     id = Column(Integer, primary_key=True, autoincrement=True)
 
@@ -107,7 +108,7 @@ class Portfolio(Base):
     holdings_snapshot = Column(JSON, nullable=True)
 
     # Relationships
-    positions = relationship("Position", back_populates="portfolios")
+    positions = relationship("Position", back_populates="portfolio")
     holdings_snapshots = relationship("PortfolioHoldingsModel", back_populates="portfolio", cascade="all, delete-orphan")
     security_holdings = relationship("SecurityHoldingsModel", back_populates="portfolio", cascade="all, delete-orphan")
     statistics_history = relationship("PortfolioStatisticsModel", back_populates="portfolio", cascade="all, delete-orphan")


### PR DESCRIPTION
**Fixed SQLAlchemy InvalidRequestError for Portfolio table redefinition**

Resolved the error: `Table 'portfolios' is already defined for this MetaData instance`

## Changes
- Added `__table_args__ = {'extend_existing': True}` to Portfolio model
- Fixed `back_populates` relationship from 'portfolios' to 'portfolio'
- Prevents table redefinition conflicts when both domain and infrastructure Portfolio classes are imported

## Root Cause
- Both domain Portfolio entity and infrastructure Portfolio model were being imported in result_storage.py
- SQLAlchemy was trying to register the same table twice
- back_populates was incorrectly referencing table name instead of attribute name

## Benefits
- Eliminates SQLAlchemy InvalidRequestError
- Maintains proper DDD separation between domain and infrastructure layers
- Correct relationship configuration
- More robust against import conflicts

Resolves #52

🤖 Generated with [Claude Code](https://claude.ai/code)