### PR TITLE
Fix backtesting ContainsKey AttributeError

### DIFF
--- a/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
+++ b/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
@@ -150,7 +150,7 @@ class MyAlgorithm(IAlgorithm):
         # Step 1: Collect signals
         signals = {}
         for ticker, model in self.models.items():
-            if ticker not in self.securities or not data.ContainsKey(self.securities[ticker].symbol):
+            if ticker not in self.securities or self.securities[ticker].symbol not in data:
                 continue
 
             history = self.history([ticker], self.lookback_window + 2, Resolution.DAILY)


### PR DESCRIPTION
Fixes issue #67

## Problem
The backtesting code was calling `data.ContainsKey()` on a `Slice` object, but `Slice` doesn't have a `ContainsKey` method.

## Solution
- Replace `data.ContainsKey()` with proper 'in' operator for Slice objects
- Slice class uses `__contains__` method, not ContainsKey method
- Resolves AttributeError: 'Slice' object has no attribute 'ContainsKey'
- Fixes issue in test_project_backtest_manager.py line 153

Generated with [Claude Code](https://claude.ai/code)