### PR TITLE
Fix backtesting securities initialization error

### DIFF
--- a/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
+++ b/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
@@ -68,7 +68,7 @@ class MyAlgorithm(IAlgorithm):
     def initialize(self):
         # Define universe and store Security objects
         self.universe = ["AAPL", "MSFT", "AMZN", "GOOGL"]
-        self.securities = {"AAPL", "MSFT", "AMZN", "GOOGL"}  # Store Security objects by ticker
+        self.securities = {}  # Dictionary to store Security objects by ticker
         for ticker in self.universe:
             try:
                 security = self.add_equity(ticker, Resolution.DAILY)


### PR DESCRIPTION
Fixes issue #67

## Problem
The backtesting code was initializing `self.securities` as a set instead of a dictionary, causing TypeError when trying to access `self.securities[ticker]`.

## Root Cause
- Line 71: `self.securities = {"AAPL", "MSFT", "AMZN", "GOOGL"}` creates a set
- Code later tries to use dictionary operations: `self.securities[ticker] = security`
- Results in TypeError when accessing `self.securities[ticker]`

## Solution
- Initialize `self.securities = {}` as empty dictionary
- Existing population logic correctly stores Security objects by ticker
- Validation logic in `on_data()` now works without errors
- Fixes both the initialization and access patterns

## Files Changed
- `src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py`

Generated with [Claude Code](https://claude.ai/code)