### PR TITLE
Fix portfolio value calculation for empty portfolio

### DIFF
--- a/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
+++ b/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
@@ -223,7 +223,18 @@ class MyAlgorithm(QCAlgorithm):
         weights = bl.solve()
 
         # Step 3: Execute trades based on BL weights
-        total_portfolio_value = float(self.portfolio.total_portfolio_value)
+        # Use cash balance when portfolio holdings are empty (initial state)
+        portfolio_holdings_value = float(self.portfolio.total_portfolio_value)
+        cash_balance = float(self.portfolio.cash_balance)
+        
+        if portfolio_holdings_value == 0.0:
+            # No holdings yet, use available cash for position sizing
+            total_portfolio_value = cash_balance
+            self.log(f"Using cash balance for position sizing: ${total_portfolio_value:.2f}")
+        else:
+            # Has holdings, use total portfolio value (holdings + cash)
+            total_portfolio_value = portfolio_holdings_value + cash_balance
+            self.log(f"Using total portfolio value: ${total_portfolio_value:.2f} (holdings: ${portfolio_holdings_value:.2f} + cash: ${cash_balance:.2f})")
         for ticker, w in weights.items():
             if ticker not in self.my_securities or self.my_securities[ticker] is None:
                 self.log(f"Warning: Cannot execute trade for {ticker} - security not available")


### PR DESCRIPTION
Fixes issue #67

## Problem
The backtesting algorithm was using `portfolio.total_portfolio_value` ($0) for position sizing instead of available cash ($100,000) when the portfolio had no holdings, causing no trades to execute.

## Root Cause
- Line 226: `total_portfolio_value = float(self.portfolio.total_portfolio_value)` returned $0
- `target_value = weight * $0 = $0` for all securities
- No trades executed because all quantities calculated to zero

## Solution
- Enhanced portfolio value calculation to check if portfolio is empty
- Use `cash_balance` ($100,000) when no holdings exist
- Use `portfolio_holdings_value + cash_balance` when holdings exist
- Added comprehensive logging to show calculation method
- Handles both initial trading and ongoing rebalancing scenarios

## Files Changed
- `src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py`

## Result
- Algorithm now uses available cash for proper position sizing
- Initial trades execute correctly using $100,000 cash balance
- Clear debugging output shows portfolio value calculation method

Generated with [Claude Code](https://claude.ai/code)