### PR TITLE
Fix portfolio holdings access AttributeError

### DIFF
--- a/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
+++ b/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
@@ -367,7 +367,7 @@ class MyAlgorithm(QCAlgorithm):
             float: Current holdings value (0.0 if no holdings)
         """
         try:
-            # Try to access portfolio holdings directly
+            # Try to access portfolio holdings directly using the correct structure
             if hasattr(self.portfolio, 'holdings') and hasattr(self.portfolio.holdings, 'holdings'):
                 # Access holdings dictionary directly
                 holdings_dict = self.portfolio.holdings.holdings
@@ -376,10 +376,14 @@ class MyAlgorithm(QCAlgorithm):
                     if hasattr(holding, 'holdings_value'):
                         return float(holding.holdings_value)
             
-            # Fallback: try portfolio[symbol] access
-            portfolio_holding = self.portfolio.get(security_symbol, None)
-            if portfolio_holding is not None and hasattr(portfolio_holding, 'holdings_value'):
-                return float(portfolio_holding.holdings_value)
+            # Alternative: try direct indexing with try/except (Portfolio doesn't have .get() method)
+            try:
+                portfolio_holding = self.portfolio[security_symbol]
+                if portfolio_holding is not None and hasattr(portfolio_holding, 'holdings_value'):
+                    return float(portfolio_holding.holdings_value)
+            except (KeyError, TypeError):
+                # Symbol not found in portfolio or portfolio doesn't support indexing
+                pass
             
             return 0.0
             


### PR DESCRIPTION
Fixes issue #67

## Problem
The backtesting code was throwing `AttributeError: 'Portfolio' object has no attribute 'get'` when trying to access portfolio holdings using `self.portfolio.get(security_symbol, None)`.

## Root Cause
- Line 380: `self.portfolio.get(security_symbol, None)` called non-existent method
- Portfolio objects don't have a `.get()` method like dictionaries
- Code was mixing dictionary access patterns with object access patterns

## Solution
- Replace `self.portfolio.get()` with proper try/except for `self.portfolio[symbol]` indexing
- Add KeyError and TypeError exception handling for missing symbols
- Maintain existing `self.portfolio.holdings.holdings` dictionary access as primary method
- Return 0.0 gracefully when holdings are not found instead of crashing

## Files Changed
- `src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py`

## Result
- No more AttributeError on portfolio access
- Safe portfolio holdings lookup with proper error handling
- Algorithm continues running instead of crashing on portfolio access
- Trades can execute correctly with proper holdings value calculation

🤖 Generated with [Claude Code](https://claude.ai/code)