### PR TITLE
Fix portfolio cash_balance AttributeError and holdings market value calculation

### DIFF
--- a/src/application/services/misbuffet/algorithm/base.py
+++ b/src/application/services/misbuffet/algorithm/base.py
@@ -769,21 +769,19 @@ class QCAlgorithm:
             float: Current holdings value (0.0 if no holdings)
         """
         try:
-            # Try to access portfolio holdings directly using the correct structure
-            if hasattr(self.portfolio, 'holdings') and hasattr(self.portfolio.holdings, 'holdings'):
-                # Access holdings dictionary directly
-                holdings_dict = self.portfolio.holdings.holdings
+            # SecurityPortfolioManager direct access - this is the correct approach
+            if hasattr(self.portfolio, '_holdings'):
+                holdings_dict = self.portfolio._holdings
                 if security_symbol in holdings_dict and holdings_dict[security_symbol] is not None:
                     holding = holdings_dict[security_symbol]
-                    if hasattr(holding, 'holdings_value'):
-                        return float(holding.holdings_value)
+                    return float(holding.market_value)  # Use market_value, not holdings_value
             
-            # Alternative: try direct indexing with try/except (Portfolio doesn't have .get() method)
+            # Alternative: try using the SecurityPortfolioManager indexing operator
             try:
                 portfolio_holding = self.portfolio[security_symbol]
-                if portfolio_holding is not None and hasattr(portfolio_holding, 'holdings_value'):
-                    return float(portfolio_holding.holdings_value)
-            except (KeyError, TypeError):
+                if portfolio_holding is not None:
+                    return float(portfolio_holding.market_value)  # Use market_value, not holdings_value
+            except (KeyError, TypeError, AttributeError):
                 # Symbol not found in portfolio or portfolio doesn't support indexing
                 pass
             

--- a/src/application/services/misbuffet/algorithm/security.py
+++ b/src/application/services/misbuffet/algorithm/security.py
@@ -334,6 +334,11 @@ class SecurityPortfolioManager:
         """Returns current total portfolio value"""
         return self.cash + self.total_holdings_value
     
+    @property
+    def cash_balance(self) -> float:
+        """Returns the cash balance (alias for cash property for compatibility)"""
+        return self.cash
+    
     def __getitem__(self, symbol: Union[Symbol, str]) -> SecurityHolding:
         """Gets or creates a SecurityHolding for the given symbol"""
         if isinstance(symbol, str):
@@ -389,6 +394,9 @@ class SecurityPortfolioManager:
         
         # Update holding
         holding.add_transaction(quantity, price, fees, timestamp)
+        
+        # Update the market price to the transaction price (important for market_value calculation)
+        holding.update_market_price(price)
         
         # Update statistics
         self.total_trades += 1


### PR DESCRIPTION
Fixes issue #67

## Problem
The backtesting system had two critical issues:
1. `AttributeError: 'SecurityPortfolioManager' object has no attribute 'cash_balance'`
2. Market orders were executing but holdings showed zero values in portfolio

## Root Causes
1. **Missing cash_balance property**: SecurityPortfolioManager had `cash` but algorithms expected `cash_balance`
2. **Holdings market value calculation**: 
   - `_get_current_holdings_value` was looking for non-existent `holdings_value` attribute
   - `SecurityHolding.market_value` was zero because `market_price` was never set after transactions

## Solution

### 1. Added cash_balance Property (security.py:338-340)
```python
@property
def cash_balance(self) -> float:
    """Returns the cash balance (alias for cash property for compatibility)"""
    return self.cash
```

### 2. Fixed Holdings Access (base.py:777)
```python
# Use market_value, not holdings_value
return float(holding.market_value)
```

### 3. Fixed Market Price Updates (security.py:398-399)
```python
# Update the market price after transaction
holding.update_market_price(price)
```

## Result
- No more `cash_balance` AttributeError
- Holdings properly registered with correct market values
- Portfolio values update correctly after market orders
- Backtesting system runs without portfolio access crashes

🤖 Generated with [Claude Code](https://claude.ai/code)