### PR TITLE
fix: resolve SQLite datatype mismatch in factor creation

### DIFF
--- a/src/domain/entities/factor/factor.py
+++ b/src/domain/entities/factor/factor.py
@@ -7,7 +7,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
-from uuid import uuid4
 
 
 class FactorBase(ABC):
@@ -21,9 +20,9 @@ class FactorBase(ABC):
         data_type: Optional[str] = None,
         source: Optional[str] = None,
         definition: Optional[str] = None,
-        factor_id: Optional[str] = None,
+        factor_id: Optional[int] = None,
     ):
-        self.id = factor_id or str(uuid4())
+        self.id = factor_id  # Repository will assign sequential ID if None
         self.name = name
         self.group = group
         self.subgroup = subgroup

--- a/src/domain/entities/factor/finance/financial_assets/equity_factor.py
+++ b/src/domain/entities/factor/finance/financial_assets/equity_factor.py
@@ -20,7 +20,7 @@ class FactorEquity(FactorSecurity):
         source: Optional[str] = None,
         definition: Optional[str] = None,
         equity_specific: Optional[str] = None,
-        factor_id: Optional[str] = None,
+        factor_id: Optional[int] = None,
     ):
         super().__init__(name, group, subgroup, data_type, source, definition, factor_id)
         self.equity_specific = equity_specific  # e.g. "return", "volatility"

--- a/src/domain/entities/factor/finance/financial_assets/financial_asset_factor.py
+++ b/src/domain/entities/factor/finance/financial_assets/financial_asset_factor.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from domain.entities.factor import FactorBase
+from domain.entities.factor.factor import FactorBase
 
 
 
@@ -16,7 +16,7 @@ class FactorFinancialAsset(FactorBase):
         data_type: Optional[str] = "numeric",
         source: Optional[str] = None,
         definition: Optional[str] = None,
-        factor_id: Optional[str] = None,
+        factor_id: Optional[int] = None,
     ):
         super().__init__(name, group, subgroup, data_type, source, definition, factor_id)
 

--- a/src/domain/entities/factor/finance/financial_assets/security_factor.py
+++ b/src/domain/entities/factor/finance/financial_assets/security_factor.py
@@ -18,7 +18,7 @@ class FactorSecurity(FactorFinancialAsset):
         data_type: Optional[str] = "numeric",
         source: Optional[str] = None,
         definition: Optional[str] = None,
-        factor_id: Optional[str] = None,
+        factor_id: Optional[int] = None,
     ):
         super().__init__(name, group, subgroup, data_type, source, definition, factor_id)
 

--- a/src/domain/entities/factor/finance/financial_assets/share_factor.py
+++ b/src/domain/entities/factor/finance/financial_assets/share_factor.py
@@ -21,7 +21,7 @@ class FactorShare(FactorEquity):
         source: Optional[str] = None,
         definition: Optional[str] = None,
         equity_specific: Optional[str] = None,
-        factor_id: Optional[str] = None,
+        factor_id: Optional[int] = None,
     ):
         super().__init__(name, group, subgroup, data_type, source, definition, factor_id)
         self.equity_specific = equity_specific  # e.g. "return", "volatility"

--- a/src/infrastructure/repositories/local_repo/factor/base_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/base_factor_repository.py
@@ -80,13 +80,13 @@ class BaseFactorRepository(BaseRepository[FactorEntity, FactorModel], ABC):
             return None
         
         factor_entity = FactorEntity(
-            id=infra_obj.id,
             name=infra_obj.name,
             group=infra_obj.group,
             subgroup=infra_obj.subgroup,
             data_type=infra_obj.data_type,
             source=infra_obj.source,
-            definition=infra_obj.definition
+            definition=infra_obj.definition,
+            factor_id=infra_obj.id
         )
 
         return factor_entity


### PR DESCRIPTION
Fixes SQLite datatype mismatch error by replacing UUID string generation with sequential integer IDs in the factor system.

## Changes
- Replace UUID generation with sequential integer ID assignment in FactorBase class
- Update all factor entity classes to use Optional[int] for factor_id parameter
- Fix repository domain conversion to use proper keyword arguments
- Ensure database schema consistency with integer ID columns

Closes #93

Generated with [Claude Code](https://claude.ai/code)