### PR TITLE
fix: Resolve Flask app conflicts by preventing duplicate app creation

### DIFF
--- a/FLASK_APP_CONFLICT_RESOLUTION_CLAUDE.md
+++ b/FLASK_APP_CONFLICT_RESOLUTION_CLAUDE.md
@@ -1,0 +1,82 @@
+# Flask App Conflict Resolution - CLAUDE.md
+
+## Issue Summary
+The Flask app conflict was occurring because:
+1. `main.py` starts Flask on localhost:5000
+2. API endpoints create manager instances that also try to start Flask on localhost:5000
+3. Result: "Address already in use" error
+
+## Root Cause Analysis
+- User observation: No place in code calls `start_interface_and_open_browser(existing_flask_app=app)`
+- The dependency injection approach was implemented but never utilized
+- Managers always called `start_interface_and_open_browser()` without parameters
+- This caused duplicate Flask app creation on the same port
+
+## Solution Implemented
+
+### 1. Manager Run Method Enhancement
+Modified `TestProjectBacktestManager.run()` to accept optional parameter:
+```python
+def run(self, start_web_interface=True):
+    """Main run method that launches web interface and executes backtest
+    
+    Args:
+        start_web_interface (bool): Whether to start web interface (default: True)
+                                   Set to False when called from existing web API
+    """
+    if start_web_interface:
+        # Start web interface and open browser
+        self.web_interface.start_interface_and_open_browser()
+    
+    # Start the actual backtest
+    return self._run_backtest()
+```
+
+### 2. API Endpoint Fix
+Modified dashboard controller to prevent duplicate Flask instances:
+```python
+# Execute actual backtest manager with configuration
+manager = TestProjectBacktestManager()
+result = manager.run(start_web_interface=False)  # Don't start another web interface
+```
+
+### 3. Code Cleanup
+- Removed unused dependency injection code from `WebInterfaceManager`
+- Simplified `start_interface_and_open_browser()` method
+- Removed `existing_flask_app` parameter that was never used
+
+## Benefits
+1. **No Port Conflicts**: Only one Flask app runs on localhost:5000
+2. **Clean Architecture**: API endpoints don't create redundant web interfaces
+3. **Backward Compatibility**: Standalone manager execution still works
+4. **Simplified Code**: Removed unnecessary complexity
+
+## Usage Patterns
+
+### Standalone Manager Execution
+```python
+manager = TestProjectBacktestManager()
+manager.run()  # Starts web interface by default
+```
+
+### API Endpoint Execution (within existing Flask app)
+```python
+manager = TestProjectBacktestManager()
+manager.run(start_web_interface=False)  # Uses existing Flask app
+```
+
+## File Changes Made
+- `src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py`
+- `src/interfaces/flask/web/controllers/dashboard_controller.py`
+- `src/application/services/misbuffet/web/web_interface.py`
+
+## Testing
+After this fix, users can:
+1. Run `python -m src.main` to start web-only interface
+2. Use dashboard buttons to execute backtests without Flask conflicts
+3. Managers execute properly without attempting duplicate Flask creation
+
+## Architecture Pattern
+**Web Controllers → API Controllers → Business Logic (without web interface startup)**
+
+This maintains separation of concerns while preventing Flask app conflicts.

--- a/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
+++ b/src/application/managers/project_managers/test_project_backtest/test_project_backtest_manager.py
@@ -303,10 +303,16 @@ class TestProjectBacktestManager(ProjectManager):
         from application.services.misbuffet.web.web_interface import WebInterfaceManager
         self.web_interface = WebInterfaceManager()
 
-    def run(self):
-        """Main run method that launches web interface and executes backtest"""
-        # Start web interface and open browser
-        self.web_interface.start_interface_and_open_browser()
+    def run(self, start_web_interface=True):
+        """Main run method that launches web interface and executes backtest
+        
+        Args:
+            start_web_interface (bool): Whether to start web interface (default: True)
+                                       Set to False when called from existing web API
+        """
+        if start_web_interface:
+            # Start web interface and open browser
+            self.web_interface.start_interface_and_open_browser()
         
         # Start the actual backtest
         return self._run_backtest()

--- a/src/application/services/misbuffet/web/web_interface.py
+++ b/src/application/services/misbuffet/web/web_interface.py
@@ -49,18 +49,14 @@ class WebInterfaceManager:
         logging.getLogger("misbuffet.engine").addHandler(progress_handler)
         logging.getLogger("TestProjectBacktestManager").addHandler(progress_handler)
     
-    def _start_web_interface(self, existing_flask_app=None):
+    def _start_web_interface(self):
         """Start Flask web interface in a separate thread"""
         from flask import Flask, render_template, request, Response, jsonify
         import json
         
-        # Use existing Flask app instance instead of creating new one
-        if existing_flask_app is not None:
-            self.flask_app = existing_flask_app
-        else:
-            # Only create new Flask app if none provided (for backward compatibility)
-            from src.interfaces.flask.flask import FlaskApp
-            self.flask_app = FlaskApp()
+        # Create Flask app instance
+        from src.interfaces.flask.flask import FlaskApp
+        self.flask_app = FlaskApp()
         
         # Import jsonify for API endpoints
         from flask import jsonify
@@ -152,21 +148,17 @@ class WebInterfaceManager:
                     'error': str(e)
                 }), 500
         
-        # Only start Flask in separate thread if we created our own instance
-        if existing_flask_app is None:
-            def run_flask():
-                try:
-                    self.flask_app.run(host='0.0.0.0', port=5000, debug=False, use_reloader=False, threaded=True)
-                except Exception as e:
-                    print(f"❌ Flask server error: {e}")
-                finally:
-                    print("🛑 Flask server stopped")
-            
-            self.flask_thread = threading.Thread(target=run_flask, daemon=True)
-            self.flask_thread.start()
-        else:
-            # If using existing Flask app, don't start a separate thread
-            print("🔗 Using existing Flask app instance")
+        # Start Flask in separate thread
+        def run_flask():
+            try:
+                self.flask_app.run(host='0.0.0.0', port=5000, debug=False, use_reloader=False, threaded=True)
+            except Exception as e:
+                print(f"❌ Flask server error: {e}")
+            finally:
+                print("🛑 Flask server stopped")
+        
+        self.flask_thread = threading.Thread(target=run_flask, daemon=True)
+        self.flask_thread.start()
         
         self.is_running = True
         print("🌐 Flask web interface started at http://localhost:5000")
@@ -184,17 +176,13 @@ class WebInterfaceManager:
             print(f"⚠️  Could not open browser automatically: {e}")
             print("📍 Please manually navigate to: http://localhost:5000/backtest_progress")
     
-    def start_interface_and_open_browser(self, existing_flask_app=None):
+    def start_interface_and_open_browser(self):
         """Start web interface and open browser"""
-        # Start Flask web interface first (or connect to existing one)
-        self._start_web_interface(existing_flask_app)
+        # Start Flask web interface
+        self._start_web_interface()
         
-        # Only wait and open browser if we started our own Flask instance
-        if existing_flask_app is None:
-            # Give Flask a moment to start
-            time.sleep(5)
-            
-            # Open browser automatically
-            self._open_browser()
-        else:
-            print("🔗 Connected to existing Flask app - browser management handled externally")
+        # Give Flask a moment to start
+        time.sleep(5)
+        
+        # Open browser automatically
+        self._open_browser()

--- a/src/interfaces/flask/web/controllers/dashboard_controller.py
+++ b/src/interfaces/flask/web/controllers/dashboard_controller.py
@@ -521,7 +521,7 @@ def api_execute_backtest():
         
         # Execute actual backtest manager with configuration
         manager = TestProjectBacktestManager()
-        result = manager.run()  # In real implementation, pass config to run method
+        result = manager.run(start_web_interface=False)  # Don't start another web interface
         
         return jsonify({
             "success": True,


### PR DESCRIPTION
This PR fixes the Flask app conflict issue identified by @diqp2001 where dependency injection code was implemented but never used.

## ✨ Solution
- Modified `TestProjectBacktestManager.run()` to accept `start_web_interface=False` parameter
- Updated API endpoint to call `manager.run(start_web_interface=False)`
- Cleaned up unused dependency injection code in `WebInterfaceManager`
- Added comprehensive documentation in `FLASK_APP_CONFLICT_RESOLUTION_CLAUDE.md`

## 🔧 Root Cause
1. `main.py` runs Flask on localhost:5000
2. API endpoints create managers that try to create ANOTHER Flask app on port 5000
3. Result: "Address already in use" conflict

## ✅ Benefits
- No more Flask app conflicts
- Clean architecture with proper separation of concerns
- Backward compatibility maintained
- Simplified codebase with unused code removed

Resolves #124

🤖 Generated with [Claude Code](https://claude.ai/code)