### PR TITLE
Fix backtest factor system dependencies

### DIFF
--- a/src/application/managers/project_managers/test_base_project/backtesting/backtest_runner.py
+++ b/src/application/managers/project_managers/test_base_project/backtesting/backtest_runner.py
@@ -77,9 +77,9 @@ class BacktestRunner:
         try:
             self.logger.info("Setting up test_base_project components...")
             
-            # Initialize factor manager
-            self.factor_manager = FactorEnginedDataManager(self.database_manager)
-            self.logger.info("✅ Factor manager initialized")
+            # Skip factor manager initialization (factor system removed)
+            self.factor_manager = None
+            self.logger.info("⚠️ Factor manager skipped (factor system removed)")
             
             # Initialize model trainer
             self.model_trainer = SpatiotemporalModelTrainer(self.database_manager)
@@ -187,9 +187,11 @@ class BacktestRunner:
             # Create algorithm instance
             algorithm = BaseProjectAlgorithm()
             
-            # Inject our components
+            # Inject our components (skip factor manager since it's not available)
             if self.factor_manager:
                 algorithm.set_factor_manager(self.factor_manager)
+            else:
+                self.logger.info("⚠️ Factor manager not available - algorithm will use CSV data directly")
             
             if self.model_trainer:
                 algorithm.set_spatiotemporal_trainer(self.model_trainer)
@@ -249,12 +251,9 @@ class BacktestRunner:
             if not self.setup_components(config):
                 raise Exception("Component setup failed")
             
-            # Step 2: Setup factor system
-            if setup_factors:
-                self.logger.info("🏗️ Setting up factor system...")
-                factor_results = self.setup_factor_system(tickers, overwrite=False)
-                if not factor_results.get('system_ready', False):
-                    raise Exception(f"Factor system setup failed: {factor_results.get('error', 'Unknown error')}")
+            # Step 2: Skip factor system setup (removed from codebase)
+            self.logger.info("🏗️ Skipping factor system setup (using CSV data directly)...")
+            factor_results = {'system_ready': True, 'note': 'Factor system removed - using CSV data'}
             
             # Step 3: Train models
             self.logger.info("🧠 Training spatiotemporal models...")

--- a/src/application/managers/project_managers/test_base_project/data/data_loader.py
+++ b/src/application/managers/project_managers/test_base_project/data/data_loader.py
@@ -45,10 +45,10 @@ class SpatiotemporalDataLoader:
                                         start_date: Optional[str] = None,
                                         end_date: Optional[str] = None) -> pd.DataFrame:
         """
-        Load historical data from the factor system (database).
+        Load historical data directly from CSV files.
         
-        Note: CSV loading is no longer needed since setup_factor_system() 
-        has already populated the database with all necessary factor values.
+        Since the factor system was removed, this method now loads data 
+        directly from CSV files in the /data/stock_data/ directory.
         
         Args:
             tickers: List of stock tickers to load
@@ -56,28 +56,28 @@ class SpatiotemporalDataLoader:
             end_date: End date in YYYY-MM-DD format
             
         Returns:
-            DataFrame with price data and factor values from the factor system
+            DataFrame with price data loaded from CSV files
         """
         if tickers is None:
             tickers = self.config['DEFAULT_UNIVERSE']
         
-        print(f"📊 Loading historical data for {len(tickers)} tickers from factor system...")
+        print(f"📊 Loading historical data for {len(tickers)} tickers from CSV files...")
         
-        # Load data only from factor system (database)
+        # Load data from CSV files instead of factor system
         combined_data = {}
         
         for ticker in tickers:
-            # Load factor data (primary and only source after factor setup)
-            factor_data = self._load_factor_data(ticker, start_date, end_date)
+            # Load CSV data (primary source since factor system was removed)
+            csv_data = self._load_csv_data(ticker, start_date, end_date)
             
-            if factor_data is not None and not factor_data.empty:
-                combined_data[ticker] = factor_data
-                print(f"  ✅ Loaded {len(factor_data)} records for {ticker}")
+            if csv_data is not None and not csv_data.empty:
+                combined_data[ticker] = csv_data
+                print(f"  ✅ Loaded {len(csv_data)} records for {ticker}")
             else:
-                print(f"  ❌ No factor data found for {ticker}")
+                print(f"  ❌ No CSV data found for {ticker}")
         
         if not combined_data:
-            raise ValueError("No data loaded for any ticker. Ensure setup_factor_system() was called first.")
+            raise ValueError("No data loaded for any ticker. Check that CSV files exist in /data/stock_data/.")
         
         # Convert to the format expected by spatiotemporal models
         return self._format_for_spatiotemporal_processing(combined_data)
@@ -86,9 +86,8 @@ class SpatiotemporalDataLoader:
         """
         Load historical price data from CSV files.
         
-        DEPRECATED: This method is no longer used in the main data loading pipeline.
-        After setup_factor_system() populates the database, all data should be loaded 
-        from the factor system via _load_factor_data(). Kept for backward compatibility.
+        This is now the primary method for loading historical data since 
+        the factor system was removed from the codebase.
         """
         csv_file = self.stock_data_path / f"{ticker}.csv"
         

--- a/src/application/managers/project_managers/test_base_project/models/model_trainer.py
+++ b/src/application/managers/project_managers/test_base_project/models/model_trainer.py
@@ -37,7 +37,7 @@ class SpatiotemporalModelTrainer:
         
         # Initialize components
         self.data_loader = SpatiotemporalDataLoader(database_manager)
-        self.factor_manager = FactorEnginedDataManager(database_manager)
+        self.factor_manager = None  # Factor system removed - using CSV data directly
         self.tensor_splitter = TensorSplitterManager()
         self.model = HybridSpatiotemporalModel()
         


### PR DESCRIPTION
## Summary
- Update SpatiotemporalDataLoader to load data from CSV files instead of factor system
- Modify BacktestRunner to skip factor system setup since it was removed
- Update ModelTrainer to work without factor manager
- System now loads OHLCV data directly from /data/stock_data/ CSV files

## Problem Resolution
Resolves the error where backtest failed because it couldn't find basic price factors (open_price, high_price, etc.) after the factor system was removed.

## Test Plan
- [x] Backtest should load OHLCV data from CSV files without errors
- [x] Factor system setup step is skipped gracefully
- [x] Model training pipeline works with CSV data source
- [x] No more "Factor not found in database" errors

Addresses issue #88 backtest factor system dependency errors.

🤖 Generated with [Claude Code](https://claude.ai/code)