### PR TITLE
Fix CSV file path resolution for backtest data loading

### DIFF
--- a/src/application/managers/project_managers/test_base_project/data/data_loader.py
+++ b/src/application/managers/project_managers/test_base_project/data/data_loader.py
@@ -36,8 +36,14 @@ class SpatiotemporalDataLoader:
         self.company_share_repository = CompanyShareRepositoryLocal(database_manager.session)
         self.share_factor_repository = ShareFactorRepository(DEFAULT_CONFIG['DATABASE']['DB_TYPE'])
         
-        # Data paths
-        self.project_root = Path(__file__).parent.parent.parent.parent.parent.parent
+        # Data paths - find project root by looking for data/stock_data directory
+        current_path = Path(__file__).resolve()
+        self.project_root = current_path
+        
+        # Walk up the directory tree to find the project root
+        while not (self.project_root / 'data' / 'stock_data').exists() and self.project_root.parent != self.project_root:
+            self.project_root = self.project_root.parent
+            
         self.stock_data_path = self.project_root / "data" / "stock_data"
     
     def load_historical_data_with_factors(self, 

--- a/src/application/managers/project_managers/test_base_project/data/factor_manager.py
+++ b/src/application/managers/project_managers/test_base_project/data/factor_manager.py
@@ -42,8 +42,14 @@ class FactorEnginedDataManager:
         # Initialize feature engineer
         self.feature_engineer = SpatiotemporalFeatureEngineer(self.database_manager)
         
-        # Data paths
-        self.project_root = Path(__file__).parent.parent.parent.parent.parent.parent
+        # Data paths - find project root by looking for data/stock_data directory
+        current_path = Path(__file__).resolve()
+        self.project_root = current_path
+        
+        # Walk up the directory tree to find the project root
+        while not (self.project_root / 'data' / 'stock_data').exists() and self.project_root.parent != self.project_root:
+            self.project_root = self.project_root.parent
+            
         self.stock_data_path = self.project_root / "data" / "stock_data"
     
     def populate_momentum_factors(self, 


### PR DESCRIPTION
## Summary
- Updated SpatiotemporalDataLoader to use robust project root detection
- Fixed FactorEnginedDataManager path calculation
- Now walks up directory tree until data/stock_data/ is found
- Resolves Windows path construction issue causing file not found errors
- Ensures cross-platform compatibility for CSV data loading

## Problem Resolution
Resolves the error where backtest failed to find CSV files because path calculation was resolving to `base_infrastructure/src/` instead of `base_infrastructure/`, causing system to look in `src/data/stock_data/` instead of `data/stock_data/`.

## Test Plan
- [x] Backtest should find CSV files in correct location
- [x] Cross-platform path resolution works for both Windows and Unix
- [x] All stock data files (AAPL, MSFT, GOOGL, AMZN, SPY) accessible
- [x] No more "CSV file not found" errors during backtest initialization

Addresses issue #88 CSV file path resolution problem.

🤖 Generated with [Claude Code](https://claude.ai/code)