### PR TITLE
Refactor model trainer to use database-driven factor loading with new domain classes

### DIFF
--- a/src/application/managers/project_managers/test_base_project_2/data/feature_engineer.py
+++ b/src/application/managers/project_managers/test_base_project_2/data/feature_engineer.py
@@ -151,61 +151,93 @@ class SpatiotemporalFeatureEngineer:
     
     def add_volatility_features(self, data: pd.DataFrame, column_name: str) -> pd.DataFrame:
         """
-        Add volatility features for risk modeling.
+        Add volatility features using new domain classes and factor manager pattern.
         """
-        print("  📉 Adding volatility features...")
+        print("  📉 Adding volatility features using domain classes...")
+        
+        from domain.entities.factor.finance.financial_assets.share_factor.volatility_factor_share_value import VolatilityFactorShareValue
+        from domain.entities.factor.finance.financial_assets.share_factor.volatility_factor_share import VolatilityFactorShare
         
         feature_data = data.copy()
         
-        # Calculate returns for volatility computation
-        if 'returns' not in feature_data.columns:
-            feature_data['returns'] = feature_data[column_name].pct_change()
+        volatility_configs = [
+            {'name': 'daily_vol', 'volatility_type': 'daily_vol', 'period': 21},
+            {'name': 'monthly_vol', 'volatility_type': 'monthly_vol', 'period': 63},
+            {'name': 'vol_of_vol', 'volatility_type': 'vol_of_vol', 'period': 21},
+            {'name': 'realized_vol', 'volatility_type': 'realized_vol', 'period': 21}
+        ]
         
-        # Daily volatility (rolling 21-day)
-        feature_data['daily_vol'] = feature_data['returns'].rolling(window=21).std() * np.sqrt(252)
-        
-        # Monthly volatility (rolling 63-day)
-        feature_data['monthly_vol'] = feature_data['returns'].rolling(window=63).std() * np.sqrt(252)
-        
-        # Volatility of volatility (vol of vol)
-        feature_data['vol_of_vol'] = feature_data['daily_vol'].rolling(window=21).std()
-        
-        # Realized volatility (sum of squared returns)
-        feature_data['realized_vol'] = feature_data['returns'].rolling(window=21).apply(
-            lambda x: np.sqrt(np.sum(x**2) * 252)
-        )
+        for vol_config in volatility_configs:
+            # Create domain entity
+            volatility_entity = VolatilityFactorShare(
+                name=vol_config['name'],
+                factor_type='volatility',
+                description=f"Volatility: {vol_config['volatility_type']}",
+                volatility_type=vol_config['volatility_type'],
+                period=vol_config['period']
+            )
+            
+            # Create calculator
+            vol_calculator = VolatilityFactorShareValue(self.database_manager, volatility_entity)
+            
+            # Calculate values and add to feature data
+            calculated_data = vol_calculator.calculate(
+                data=feature_data,
+                column_name=column_name,
+                volatility_type=vol_config['volatility_type'],
+                period=vol_config['period']
+            )
+            
+            # Add the calculated column to feature data
+            feature_data[vol_config['name']] = calculated_data['indicator_value']
         
         return feature_data
     
     def add_target_variables(self, data: pd.DataFrame, column_name: str, freq: int = 1) -> pd.DataFrame:
         """
-        Add target variables for model training.
+        Add target variables using new domain classes and factor manager pattern.
         
-        Creates both scaled and non-scaled target returns for model training,
-        following the spatiotemporal_momentum_manager pattern.
+        Creates both scaled and non-scaled target returns for model training.
         """
-        print("  🎯 Adding target variables...")
+        print("  🎯 Adding target variables using domain classes...")
         
-        try:
-            # Use the data_manager methods for target creation
-            enhanced_data, target_col = self.data_manager.add_target(
-                data=data, 
-                column_name=column_name, 
-                freq=freq
+        from domain.entities.factor.finance.financial_assets.share_factor.target_factor_share_value import TargetFactorShareValue
+        from domain.entities.factor.finance.financial_assets.share_factor.target_factor_share import TargetFactorShare
+        
+        feature_data = data.copy()
+        
+        target_configs = [
+            {'name': 'target_returns', 'target_type': 'target_returns', 'forecast_horizon': freq, 'is_scaled': True},
+            {'name': 'target_returns_nonscaled', 'target_type': 'target_returns_nonscaled', 'forecast_horizon': freq, 'is_scaled': False}
+        ]
+        
+        for target_config in target_configs:
+            # Create domain entity
+            target_entity = TargetFactorShare(
+                name=target_config['name'],
+                factor_type='target',
+                description=f"Target: {target_config['target_type']}",
+                target_type=target_config['target_type'],
+                forecast_horizon=target_config['forecast_horizon'],
+                is_scaled=target_config['is_scaled']
             )
             
-            enhanced_data, target_non_scaled_col = self.data_manager.add_target_non_scaled(
-                data=enhanced_data,
+            # Create calculator
+            target_calculator = TargetFactorShareValue(self.database_manager, target_entity)
+            
+            # Calculate values and add to feature data
+            calculated_data = target_calculator.calculate(
+                data=feature_data,
                 column_name=column_name,
-                freq=freq
+                target_type=target_config['target_type'],
+                forecast_horizon=target_config['forecast_horizon'],
+                is_scaled=target_config['is_scaled']
             )
             
-            return enhanced_data
-            
-        except Exception as e:
-            print(f"  ⚠️  Error in target creation: {str(e)}")
-            # Fallback: create basic target variables
-            return self._create_basic_targets(data, column_name, freq)
+            # Add the calculated column to feature data
+            feature_data[target_config['name']] = calculated_data['indicator_value']
+        
+        return feature_data
     
     def _create_basic_targets(self, data: pd.DataFrame, column_name: str, freq: int = 1) -> pd.DataFrame:
         """Fallback method to create basic target variables."""

--- a/src/domain/entities/factor/finance/financial_assets/share_factor/target_factor_share.py
+++ b/src/domain/entities/factor/finance/financial_assets/share_factor/target_factor_share.py
@@ -1,0 +1,32 @@
+# domain/entities/factor/finance/financial_assets/share_factor/target_factor_share.py
+
+from dataclasses import dataclass
+from typing import Optional
+from decimal import Decimal
+import pandas as pd
+
+from .share_factor import ShareFactor
+
+
+@dataclass
+class TargetFactorShare(ShareFactor):
+    """
+    Domain entity representing target variable factors for share analysis.
+    Handles target returns for model training (both scaled and non-scaled).
+    """
+    
+    target_type: str  # 'target_returns', 'target_returns_nonscaled'
+    forecast_horizon: int  # number of periods ahead to predict (e.g., 1 for 1-day ahead)
+    is_scaled: bool = True  # whether target is normalized/scaled
+    
+    def __post_init__(self):
+        super().__post_init__()
+        if not self.target_type:
+            raise ValueError("target_type is required for TargetFactorShare")
+        if not self.forecast_horizon or self.forecast_horizon <= 0:
+            raise ValueError("forecast_horizon must be a positive integer")
+            
+    def get_target_description(self) -> str:
+        """Get human-readable description of this target factor."""
+        scaling = "scaled" if self.is_scaled else "non-scaled"
+        return f"{self.forecast_horizon}-day forward returns ({scaling})"

--- a/src/domain/entities/factor/finance/financial_assets/share_factor/target_factor_share_value.py
+++ b/src/domain/entities/factor/finance/financial_assets/share_factor/target_factor_share_value.py
@@ -1,0 +1,103 @@
+# domain/entities/factor/finance/financial_assets/share_factor/target_factor_share_value.py
+
+from dataclasses import dataclass
+from typing import Optional, List
+from decimal import Decimal
+import pandas as pd
+import numpy as np
+
+from application.managers.database_managers.database_manager import DatabaseManager
+from .target_factor_share import TargetFactorShare
+from domain.entities.factor.finance.financial_assets.share_factor.share_factor_value import ShareFactorValue
+
+
+@dataclass
+class TargetFactorShareValue(ShareFactorValue):
+    """
+    Domain entity representing target variable factor values for shares.
+    Follows the same repository storage pattern as other factor value classes.
+    """
+
+    factor: Optional[TargetFactorShare] = None
+
+    def __init__(self, database_manager: DatabaseManager, factor: TargetFactorShare):
+        self.factor = factor
+
+    def calculate_forward_returns(self, prices: pd.Series, horizon: int = 1) -> pd.Series:
+        """Calculate forward returns for target variables."""
+        return prices.pct_change(horizon).shift(-horizon)
+    
+    def calculate_scaled_returns(self, returns: pd.Series, window: int = 252, min_periods: int = 21) -> pd.Series:
+        """Calculate z-score normalized returns."""
+        rolling_mean = returns.rolling(window=window, min_periods=min_periods).mean()
+        rolling_std = returns.rolling(window=window, min_periods=min_periods).std()
+        return (returns - rolling_mean) / rolling_std
+
+    def calculate(self, data: pd.DataFrame, column_name: str, target_type: str, 
+                 forecast_horizon: int, is_scaled: bool = True) -> pd.DataFrame:
+        """
+        Calculate target variable values.
+        
+        Args:
+            data: DataFrame with price data
+            column_name: Name of the price column
+            target_type: Type of target ('target_returns' or 'target_returns_nonscaled')
+            forecast_horizon: Number of periods ahead to predict
+            is_scaled: Whether to apply scaling/normalization
+            
+        Returns:
+            DataFrame with target values in 'indicator_value' column
+        """
+        result_data = data.copy()
+        
+        # Calculate forward returns
+        forward_returns = self.calculate_forward_returns(
+            result_data[column_name], forecast_horizon
+        )
+        
+        if is_scaled:
+            # Apply z-score normalization
+            result_data['indicator_value'] = self.calculate_scaled_returns(forward_returns)
+        else:
+            # Use raw forward returns
+            result_data['indicator_value'] = forward_returns
+        
+        return result_data
+
+    def store_factor_values(self, repository, factor, share, data: pd.DataFrame, 
+                          column_name: str, target_type: str, forecast_horizon: int, 
+                          is_scaled: bool, overwrite: bool) -> int:
+        """
+        Store target factor values using repository pattern.
+        Follows same approach as momentum, technical, and volatility factors.
+        
+        Args:
+            repository: Share factor repository
+            factor: Factor entity from repository
+            share: Share entity
+            data: DataFrame with price data
+            column_name: Price column name
+            target_type: Type of target variable
+            forecast_horizon: Number of periods ahead to predict
+            is_scaled: Whether to apply scaling
+            overwrite: Whether to overwrite existing values
+            
+        Returns:
+            Number of values stored
+        """
+        try:
+            # Calculate target values
+            calculated_data = self.calculate(
+                data, column_name, target_type, forecast_horizon, is_scaled
+            )
+            
+            # Use repository's _store_factor_values method
+            values_stored = repository._store_factor_values(
+                factor, share, calculated_data, 'indicator_value', overwrite
+            )
+            
+            return values_stored
+            
+        except Exception as e:
+            print(f"  ⚠️  Error storing {target_type} values: {str(e)}")
+            return 0

--- a/src/domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share.py
+++ b/src/domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share.py
@@ -1,0 +1,37 @@
+# domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share.py
+
+from dataclasses import dataclass
+from typing import Optional
+from decimal import Decimal
+import pandas as pd
+
+from .share_factor import ShareFactor
+
+
+@dataclass
+class VolatilityFactorShare(ShareFactor):
+    """
+    Domain entity representing volatility factors for share analysis.
+    Handles various types of volatility calculations like daily_vol, monthly_vol, vol_of_vol, realized_vol.
+    """
+    
+    volatility_type: str  # 'daily_vol', 'monthly_vol', 'vol_of_vol', 'realized_vol'
+    period: int  # window size for volatility calculation
+    annualization_factor: Optional[float] = None  # e.g., sqrt(252) for annualizing
+    
+    def __post_init__(self):
+        super().__post_init__()
+        if not self.volatility_type:
+            raise ValueError("volatility_type is required for VolatilityFactorShare")
+        if not self.period or self.period <= 0:
+            raise ValueError("period must be a positive integer")
+            
+    def get_volatility_description(self) -> str:
+        """Get human-readable description of this volatility factor."""
+        type_descriptions = {
+            'daily_vol': f'{self.period}-day rolling volatility',
+            'monthly_vol': f'{self.period}-day rolling monthly volatility', 
+            'vol_of_vol': f'Volatility of volatility ({self.period}-day)',
+            'realized_vol': f'Realized volatility ({self.period}-day)'
+        }
+        return type_descriptions.get(self.volatility_type, f'Volatility factor ({self.volatility_type})')

--- a/src/domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share_value.py
+++ b/src/domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share_value.py
@@ -1,0 +1,119 @@
+# domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share_value.py
+
+from dataclasses import dataclass
+from typing import Optional, List
+from decimal import Decimal
+import pandas as pd
+import numpy as np
+
+from application.managers.database_managers.database_manager import DatabaseManager
+from .volatility_factor_share import VolatilityFactorShare
+from domain.entities.factor.finance.financial_assets.share_factor.share_factor_value import ShareFactorValue
+
+
+@dataclass
+class VolatilityFactorShareValue(ShareFactorValue):
+    """
+    Domain entity representing volatility factor values for shares.
+    Follows the same repository storage pattern as MomentumFactorShareValue and TechnicalFactorShareValue.
+    """
+
+    factor: Optional[VolatilityFactorShare] = None
+
+    def __init__(self, database_manager: DatabaseManager, factor: VolatilityFactorShare):
+        self.factor = factor
+
+    def calculate_daily_volatility(self, returns: pd.Series, period: int = 21) -> pd.Series:
+        """Calculate daily volatility (annualized rolling standard deviation)."""
+        return returns.rolling(window=period).std() * np.sqrt(252)
+    
+    def calculate_monthly_volatility(self, returns: pd.Series, period: int = 63) -> pd.Series:
+        """Calculate monthly volatility (annualized rolling standard deviation)."""
+        return returns.rolling(window=period).std() * np.sqrt(252)
+    
+    def calculate_volatility_of_volatility(self, daily_vol: pd.Series, period: int = 21) -> pd.Series:
+        """Calculate volatility of volatility (vol of vol)."""
+        return daily_vol.rolling(window=period).std()
+    
+    def calculate_realized_volatility(self, returns: pd.Series, period: int = 21) -> pd.Series:
+        """Calculate realized volatility (sum of squared returns)."""
+        return returns.rolling(window=period).apply(
+            lambda x: np.sqrt(np.sum(x**2) * 252)
+        )
+
+    def calculate(self, data: pd.DataFrame, column_name: str, volatility_type: str, period: int) -> pd.DataFrame:
+        """
+        Calculate volatility factor values based on type.
+        
+        Args:
+            data: DataFrame with price data
+            column_name: Name of the price column
+            volatility_type: Type of volatility calculation
+            period: Window size for calculation
+            
+        Returns:
+            DataFrame with volatility values in 'indicator_value' column
+        """
+        result_data = data.copy()
+        
+        # Calculate returns if not present
+        if 'returns' not in result_data.columns:
+            result_data['returns'] = result_data[column_name].pct_change()
+        
+        # Calculate volatility based on type
+        if volatility_type == 'daily_vol':
+            result_data['indicator_value'] = self.calculate_daily_volatility(
+                result_data['returns'], period
+            )
+        elif volatility_type == 'monthly_vol':
+            result_data['indicator_value'] = self.calculate_monthly_volatility(
+                result_data['returns'], period
+            )
+        elif volatility_type == 'vol_of_vol':
+            # First calculate daily volatility, then vol of vol
+            daily_vol = self.calculate_daily_volatility(result_data['returns'], 21)
+            result_data['indicator_value'] = self.calculate_volatility_of_volatility(
+                daily_vol, period
+            )
+        elif volatility_type == 'realized_vol':
+            result_data['indicator_value'] = self.calculate_realized_volatility(
+                result_data['returns'], period
+            )
+        else:
+            raise ValueError(f"Unknown volatility type: {volatility_type}")
+        
+        return result_data
+
+    def store_factor_values(self, repository, factor, share, data: pd.DataFrame, 
+                          column_name: str, volatility_type: str, period: int, overwrite: bool) -> int:
+        """
+        Store volatility factor values using repository pattern.
+        Follows same approach as momentum and technical factors.
+        
+        Args:
+            repository: Share factor repository
+            factor: Factor entity from repository
+            share: Share entity
+            data: DataFrame with price data
+            column_name: Price column name
+            volatility_type: Type of volatility calculation  
+            period: Window for volatility calculation
+            overwrite: Whether to overwrite existing values
+            
+        Returns:
+            Number of values stored
+        """
+        try:
+            # Calculate volatility values
+            calculated_data = self.calculate(data, column_name, volatility_type, period)
+            
+            # Use repository's _store_factor_values method
+            values_stored = repository._store_factor_values(
+                factor, share, calculated_data, 'indicator_value', overwrite
+            )
+            
+            return values_stored
+            
+        except Exception as e:
+            print(f"  ⚠️  Error storing {volatility_type} values: {str(e)}")
+            return 0


### PR DESCRIPTION
Fixes #139

- Create VolatilityFactorShare and VolatilityFactorShareValue domain entities
- Create TargetFactorShare and TargetFactorShareValue domain entities
- Refactor _prepare_factor_data to use direct database queries instead of CSV loading
- Update factor population to follow backtestRunner pattern with all factor types
- Separate factor storage from tensor creation as requested
- Update feature engineer to use new domain classes for volatility and target features
- Maintain consistent repository pattern across all factor types

Generated with [Claude Code](https://claude.ai/code)