### PR TITLE
Fix ShareVolatilityFactor and ShareTargetFactor constructor issues and list object error

### DIFF
--- a/src/application/managers/project_managers/test_base_project_2/data/factor_manager.py
+++ b/src/application/managers/project_managers/test_base_project_2/data/factor_manager.py
@@ -681,6 +681,9 @@ class FactorEnginedDataManager:
         if not share:
             return None
         
+        # Handle list return from get_by_ticker
+        share = share[0] if isinstance(share, list) else share
+        
         # Get factors for the specified groups
         factors = self.share_factor_repository.get_factors_by_groups(factor_groups)
         

--- a/src/domain/entities/factor/finance/financial_assets/share_factor/target_factor_share.py
+++ b/src/domain/entities/factor/finance/financial_assets/share_factor/target_factor_share.py
@@ -1,28 +1,37 @@
 # domain/entities/factor/finance/financial_assets/share_factor/target_factor_share.py
 
-from dataclasses import dataclass
+from __future__ import annotations
 from typing import Optional
-from decimal import Decimal
-import pandas as pd
-
-from .share_factor import ShareFactor
+from domain.entities.factor.finance.financial_assets.share_factor.share_factor import ShareFactor
 
 
-@dataclass
 class ShareTargetFactor(ShareFactor):
     """
     Domain entity representing target variable factors for share analysis.
     Handles target returns for model training (both scaled and non-scaled).
     """
-    
-    target_type: str  # 'target_returns', 'target_returns_nonscaled'
-    forecast_horizon: int  # number of periods ahead to predict (e.g., 1 for 1-day ahead)
-    is_scaled: bool = True  # whether target is normalized/scaled
-    
-    def __post_init__(self):
-        super().__post_init__()
+
+    def __init__(
+        self,
+        name: str,
+        target_type: str,  # 'target_returns', 'target_returns_nonscaled'
+        forecast_horizon: int,  # number of periods ahead to predict (e.g., 1 for 1-day ahead)
+        group: str = "Target",
+        subgroup: Optional[str] = "Returns",
+        data_type: str = "numeric",
+        source: Optional[str] = "Internal",
+        definition: Optional[str] = None,
+        factor_id: Optional[int] = None,
+        is_scaled: bool = True,  # whether target is normalized/scaled
+    ):
+        definition = definition or f"{target_type} factor (horizon: {forecast_horizon})"
+        super().__init__(name=name, group=group, subgroup=subgroup, data_type=data_type, source=source, definition=definition, factor_id=factor_id)
+        self.target_type = target_type
+        self.forecast_horizon = forecast_horizon
+        self.is_scaled = is_scaled
+        
         if not self.target_type:
-            raise ValueError("target_type is required for TargetFactorShare")
+            raise ValueError("target_type is required for ShareTargetFactor")
         if not self.forecast_horizon or self.forecast_horizon <= 0:
             raise ValueError("forecast_horizon must be a positive integer")
             
@@ -30,3 +39,6 @@ class ShareTargetFactor(ShareFactor):
         """Get human-readable description of this target factor."""
         scaling = "scaled" if self.is_scaled else "non-scaled"
         return f"{self.forecast_horizon}-day forward returns ({scaling})"
+
+    def __str__(self):
+        return f"ShareTargetFactor(name={self.name}, target_type={self.target_type}, forecast_horizon={self.forecast_horizon})"

--- a/src/domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share.py
+++ b/src/domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share.py
@@ -1,28 +1,37 @@
 # domain/entities/factor/finance/financial_assets/share_factor/volatility_factor_share.py
 
-from dataclasses import dataclass
+from __future__ import annotations
 from typing import Optional
-from decimal import Decimal
-import pandas as pd
-
-from .share_factor import ShareFactor
+from domain.entities.factor.finance.financial_assets.share_factor.share_factor import ShareFactor
 
 
-@dataclass
 class ShareVolatilityFactor(ShareFactor):
     """
     Domain entity representing volatility factors for share analysis.
     Handles various types of volatility calculations like daily_vol, monthly_vol, vol_of_vol, realized_vol.
     """
-    
-    volatility_type: str  # 'daily_vol', 'monthly_vol', 'vol_of_vol', 'realized_vol'
-    period: int  # window size for volatility calculation
-    annualization_factor: Optional[float] = None  # e.g., sqrt(252) for annualizing
-    
-    def __post_init__(self):
-        super().__post_init__()
+
+    def __init__(
+        self,
+        name: str,
+        volatility_type: str,  # 'daily_vol', 'monthly_vol', 'vol_of_vol', 'realized_vol'
+        period: int,  # window size for volatility calculation
+        group: str = "Volatility",
+        subgroup: Optional[str] = "Realized",
+        data_type: str = "numeric",
+        source: Optional[str] = "Internal",
+        definition: Optional[str] = None,
+        factor_id: Optional[int] = None,
+        annualization_factor: Optional[float] = None,  # e.g., sqrt(252) for annualizing
+    ):
+        definition = definition or f"{volatility_type} volatility factor (period: {period})"
+        super().__init__(name=name, group=group, subgroup=subgroup, data_type=data_type, source=source, definition=definition, factor_id=factor_id)
+        self.volatility_type = volatility_type
+        self.period = period
+        self.annualization_factor = annualization_factor
+        
         if not self.volatility_type:
-            raise ValueError("volatility_type is required for VolatilityFactorShare")
+            raise ValueError("volatility_type is required for ShareVolatilityFactor")
         if not self.period or self.period <= 0:
             raise ValueError("period must be a positive integer")
             
@@ -35,3 +44,6 @@ class ShareVolatilityFactor(ShareFactor):
             'realized_vol': f'Realized volatility ({self.period}-day)'
         }
         return type_descriptions.get(self.volatility_type, f'Volatility factor ({self.volatility_type})')
+
+    def __str__(self):
+        return f"ShareVolatilityFactor(name={self.name}, volatility_type={self.volatility_type}, period={self.period})"


### PR DESCRIPTION
Fixes #139

- Convert ShareVolatilityFactor from @dataclass to traditional constructor matching ShareMomentumFactor pattern
- Convert ShareTargetFactor from @dataclass to traditional constructor matching ShareMomentumFactor pattern  
- Fix 'list' object has no attribute 'id' error in _get_ticker_factor_data method
- Add proper share list handling in factor data loading
- Both classes now properly inherit from ShareFactor with correct parameter handling

Fixes factor creation errors preventing volatility and target factor population.

Generated with [Claude Code](https://claude.ai/code)