### PR TITLE
fix: replace deprecated pandas fillna method calls

### DIFF
--- a/src/application/managers/api_managers/api_quandl_manager/api_quandl_manager.py
+++ b/src/application/managers/api_managers/api_quandl_manager/api_quandl_manager.py
@@ -67,7 +67,7 @@ class QuandlApiManager(APIManager):
         Returns:
         - DataFrame: Data with missing values filled.
         """
-        return data[data["close"].first_valid_index() : data["close"].last_valid_index()].fillna(method="ffill")
+        return data[data["close"].first_valid_index() : data["close"].last_valid_index()].ffill()
 
     def pull_pinnacle_data(self, ticker: str, folder: str, cut: str) -> pd.DataFrame:
         """

--- a/src/application/managers/project_managers/test_base_project/data/data_loader.py
+++ b/src/application/managers/project_managers/test_base_project/data/data_loader.py
@@ -200,7 +200,7 @@ class SpatiotemporalDataLoader:
         combined_df = combined_df.sort_index()
         
         # Fill missing values using forward fill then backward fill
-        combined_df = combined_df.fillna(method='ffill').fillna(method='bfill')
+        combined_df = combined_df.ffill().bfill()
         
         return combined_df
     

--- a/src/application/managers/project_managers/test_base_project/data/factor_manager.py
+++ b/src/application/managers/project_managers/test_base_project/data/factor_manager.py
@@ -531,6 +531,6 @@ class FactorEnginedDataManager:
         # Combine and clean
         combined_df = pd.concat(all_data, axis=1)
         combined_df = combined_df.sort_index()
-        combined_df = combined_df.fillna(method='ffill').fillna(method='bfill')
+        combined_df = combined_df.ffill().bfill()
         
         return combined_df

--- a/src/application/managers/project_managers/test_base_project/models/tensor_splitter.py
+++ b/src/application/managers/project_managers/test_base_project/models/tensor_splitter.py
@@ -219,7 +219,7 @@ class TensorSplitterManager:
                 result_data[vol_col] = 0.01  # Default volatility
         
         # Fill missing values
-        result_data = result_data.fillna(method='ffill').fillna(method='bfill').fillna(0)
+        result_data = result_data.ffill().bfill().fillna(0)
         
         return result_data
     

--- a/src/application/managers/project_managers/test_base_project_2/data/data_loader.py
+++ b/src/application/managers/project_managers/test_base_project_2/data/data_loader.py
@@ -200,7 +200,7 @@ class SpatiotemporalDataLoader:
         combined_df = combined_df.sort_index()
         
         # Fill missing values using forward fill then backward fill
-        combined_df = combined_df.fillna(method='ffill').fillna(method='bfill')
+        combined_df = combined_df.ffill().bfill()
         
         return combined_df
     

--- a/src/application/managers/project_managers/test_base_project_2/data/factor_manager.py
+++ b/src/application/managers/project_managers/test_base_project_2/data/factor_manager.py
@@ -722,7 +722,7 @@ class FactorEnginedDataManager:
         # Combine and clean
         combined_df = pd.concat(all_data, axis=1)
         combined_df = combined_df.sort_index()
-        combined_df = combined_df.fillna(method='ffill').fillna(method='bfill')
+        combined_df = combined_df.ffill().bfill()
         
         return combined_df
     

--- a/src/application/managers/project_managers/test_base_project_2/models/tensor_splitter.py
+++ b/src/application/managers/project_managers/test_base_project_2/models/tensor_splitter.py
@@ -219,7 +219,7 @@ class TensorSplitterManager:
                 result_data[vol_col] = 0.01  # Default volatility
         
         # Fill missing values
-        result_data = result_data.fillna(method='ffill').fillna(method='bfill').fillna(0)
+        result_data = result_data.ffill().bfill().fillna(0)
         
         return result_data
     


### PR DESCRIPTION
Replace deprecated fillna(method='ffill') and fillna(method='bfill') with modern pandas syntax using ffill() and bfill() methods.

Updated 7 files across the codebase to resolve FutureWarning messages about deprecated pandas methods.

Fixes #150

Generated with [Claude Code](https://claude.ai/code)