### PR TITLE
fix: defer initial training until after dependency injection

### DIFF
--- a/src/application/managers/project_managers/test_base_project_2/backtesting/base_project_algorithm.py
+++ b/src/application/managers/project_managers/test_base_project_2/backtesting/base_project_algorithm.py
@@ -86,8 +86,9 @@ class BaseProjectAlgorithm(QCAlgorithm):
         # Initialize test_base_project components
         self._initialize_base_project_components()
         
-        # Initial training
-        self._train_models(self.time)
+        # Defer initial training until dependencies are injected
+        # This will be triggered by the first on_data() call or explicit training call
+        self._initial_training_completed = False
 
     def _initialize_base_project_components(self):
         """Initialize the test_base_project specific components."""
@@ -528,6 +529,16 @@ class BaseProjectAlgorithm(QCAlgorithm):
             self.momentum_strategy is not None):
             self._dependencies_injected = True
             self.log("🎉 All dependencies injected - algorithm fully configured!")
+            
+            # Trigger initial training now that all dependencies are available
+            if not self._initial_training_completed:
+                self.log("🚀 Performing deferred initial training...")
+                try:
+                    self._train_models(self.time)
+                    self._initial_training_completed = True
+                    self.log("✅ Initial training completed successfully")
+                except Exception as e:
+                    self.log(f"⚠️ Initial training failed: {str(e)}")
         else:
             missing = []
             if self.factor_manager is None:


### PR DESCRIPTION
Prevent BaseProjectAlgorithm from accessing spatiotemporal_trainer during initialization before BacktestRunner injects dependencies.

- Move initial model training from initialize() to _check_dependencies_complete()
- Add _initial_training_completed flag to track deferred training
- Trigger training automatically when all dependencies are injected
- Fixes 'BaseProjectAlgorithm' object has no attribute 'spatiotemporal_trainer' error

Fixes #150

🤖 Generated with [Claude Code](https://claude.ai/code)