### PR TITLE
refactor: update FactorValue dependencies after entity_type moved to FactorModel

### DIFF
--- a/src/application/managers/project_managers/test_base_project/data/factor_manager.py
+++ b/src/application/managers/project_managers/test_base_project/data/factor_manager.py
@@ -490,14 +490,7 @@ class FactorEnginedDataManager:
 
         for factor in momentum_domain_factors:
             # Use factor calculation service instead of direct value class
-            momentum_results = self.factor_calculation_service.calculate_and_store_momentum(
-                factor=factor,
-                entity_id=None,  # Will be set per ticker
-                entity_type='share',
-                prices=[],  # Will be populated per ticker
-                dates=[],   # Will be populated per ticker
-                overwrite=overwrite
-            )
+            # Proper calculations are done per ticker below
             
             for ticker in tickers:
                 try:
@@ -511,7 +504,6 @@ class FactorEnginedDataManager:
                         momentum_results = self.factor_calculation_service.calculate_and_store_momentum(
                             factor=factor,
                             entity_id=company.id,
-                            entity_type='share',
                             ticker=ticker,
                             overwrite=overwrite
                         )
@@ -534,14 +526,7 @@ class FactorEnginedDataManager:
 
         for factor in technical_domain_factors:
             # Use factor calculation service instead of direct value class
-            technical_results = self.factor_calculation_service.calculate_and_store_technical(
-                factor=factor,
-                entity_id=None,  # Will be set per ticker
-                entity_type='share',
-                prices=[],  # Will be populated per ticker
-                dates=[],   # Will be populated per ticker
-                overwrite=overwrite
-            )
+# Remove unused first call - proper calculations are done per ticker below
             
             for ticker in tickers:
                 try:
@@ -567,9 +552,7 @@ class FactorEnginedDataManager:
                         technical_results = self.factor_calculation_service.calculate_and_store_technical(
                             factor=factor,
                             entity_id=company.id,
-                            entity_type='share',
-                            prices=prices,
-                            dates=dates,
+                            ticker=ticker,
                             overwrite=overwrite
                         )
                         values_stored = len(technical_results) if technical_results else 0
@@ -882,14 +865,7 @@ class FactorEnginedDataManager:
                     continue
                 
                 # Use factor calculation service instead of direct value class
-                volatility_results = self.factor_calculation_service.calculate_and_store_volatility(
-                    factor=volatility_factor,
-                    entity_id=None,  # Will be set per ticker
-                    entity_type='share',
-                    prices=[],  # Will be populated per ticker
-                    dates=[],   # Will be populated per ticker
-                    overwrite=overwrite
-                )
+                # Proper calculations are done per ticker below
                 
                 # Process each ticker
                 for ticker in tickers:
@@ -910,9 +886,7 @@ class FactorEnginedDataManager:
                         volatility_results = self.factor_calculation_service.calculate_and_store_volatility(
                             factor=volatility_factor,
                             entity_id=share.id,
-                            entity_type='share',
-                            prices=prices,
-                            dates=dates,
+                            ticker=ticker,
                             overwrite=overwrite
                         )
                         values_stored = len(volatility_results) if volatility_results else 0

--- a/src/infrastructure/models/factor/factor_model.py
+++ b/src/infrastructure/models/factor/factor_model.py
@@ -173,6 +173,6 @@ class FactorValue(Base):
     factor = relationship("FactorModel", back_populates="factor_values")
 
     def __repr__(self):
-        return f"<FactorValue(id={self.id}, factor_id={self.factor_id}, entity_id={self.entity_id}, entity_type={self.entity_type}, date={self.date}, value={self.value})>"
+        return f"<FactorValue(id={self.id}, factor_id={self.factor_id}, entity_id={self.entity_id}, date={self.date}, value={self.value})>"
 
 

--- a/src/infrastructure/repositories/mappers/factor/factor_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/factor_mapper.py
@@ -22,6 +22,26 @@ from domain.entities.factor.finance.financial_assets.share_factor.share_target_f
 from domain.entities.factor.finance.financial_assets.share_factor.share_volatility_factor import ShareVolatilityFactor as ShareVolatilityFactorEntity
 
 
+def _get_entity_type_from_factor(factor) -> str:
+    """
+    Helper function to determine entity_type from factor type.
+    This avoids circular dependency with FactorCalculationService.
+    """
+    factor_class_name = factor.__class__.__name__
+    
+    # Map factor types to entity types
+    if any(share_type in factor_class_name for share_type in ['Share', 'share']):
+        return 'share'
+    elif any(equity_type in factor_class_name for equity_type in ['Equity', 'equity']):
+        return 'equity'
+    elif any(country_type in factor_class_name for country_type in ['Country', 'country']):
+        return 'country'
+    elif any(continent_type in factor_class_name for continent_type in ['Continent', 'continent']):
+        return 'continent'
+    else:
+        return 'share'  # Default fallback
+
+
 
 class FactorMapper:
     """Mapper for Factor domain entity and ORM model conversion."""
@@ -206,6 +226,7 @@ class FactorMapper:
             'data_type': domain_entity.data_type,
             'source': domain_entity.source,
             'definition': domain_entity.definition,
+            'entity_type': _get_entity_type_from_factor(domain_entity),  # Derive entity_type from factor type
         }
         
         # Determine the appropriate ORM model and set specialized fields

--- a/src/infrastructure/repositories/mappers/factor/factor_value_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/factor_value_mapper.py
@@ -29,7 +29,6 @@ class FactorValueMapper:
             id=orm_model.id,
             factor_id=orm_model.factor_id,
             entity_id=orm_model.entity_id,
-            entity_type=getattr(orm_model, 'entity_type', 'share'),
             date=orm_model.date,
             value=Decimal(str(orm_model.value)) if orm_model.value is not None else Decimal('0')
         )
@@ -41,7 +40,6 @@ class FactorValueMapper:
             id=domain_entity.id,
             factor_id=domain_entity.factor_id,
             entity_id=domain_entity.entity_id,
-            entity_type=getattr(domain_entity, 'entity_type', 'share'),
             date=domain_entity.date,
             value=domain_entity.value
         )


### PR DESCRIPTION
Updates all dependencies after moving entity_type from FactorValue to FactorModel, maintaining functionality while reflecting the new database schema.

## 🔧 Key Changes:
- Fix FactorValue model __repr__ to remove entity_type reference
- Update FactorValueMapper to remove entity_type handling from FactorValue
- Add entity_type derivation helper function for consistent mapping
- Update FactorCalculationService methods to derive entity_type from factor type
- Remove entity_type parameters from all calculation methods
- Update factor_manager calls to use new service signature
- Add entity_type mapping in FactorMapper for proper ORM conversion

## 🚀 Benefits:
- ✅ Eliminated invalid references to entity_type from FactorValue
- ✅ Consistent entity_type derivation from factor class names
- ✅ Simplified service interface without redundant parameters
- ✅ Proper database schema alignment with entity_type in FactorModel
- ✅ Maintained backward compatibility through legacy methods

Closes #176

🤖 Generated with [Claude Code](https://claude.ai/code)