### PR TITLE
feat: refactor MisbuffetEngine to use services layer and support multiple entity types

### DIFF
--- a/src/application/services/misbuffet/__init__.py
+++ b/src/application/services/misbuffet/__init__.py
@@ -70,7 +70,7 @@ __version__ = "1.0.0"
 __author__ = "QuantConnect Lean Python Implementation"
 
 # Import engine components from separate file
-from .engine.misbuffet_engine import MisbuffetEngine, BacktestResult
+from .engine.misbuffet_engine import MisbuffetEngine, MisbuffetEngineConfig, BacktestResult
 
 
 # Main Misbuffet class with engine integration
@@ -127,8 +127,9 @@ class Misbuffet:
                 exec(f.read(), config_globals)
             self.logger.info(f"Loaded engine configuration from {config_file}")
         
-        # Create engine with handlers
-        engine = MisbuffetEngine()
+        # Create engine with handlers (using default config for backward compatibility)
+        engine_config = MisbuffetEngineConfig()  # Default to company_shares
+        engine = MisbuffetEngine(engine_config)
         engine._create_handlers()
         
         self.engine = engine
@@ -143,6 +144,7 @@ __all__ = [
     
     # Engine classes
     "MisbuffetEngine",
+    "MisbuffetEngineConfig", 
     "BacktestResult",
     
     # Core modules are exported via their own __all__ lists

--- a/test_interval_config.py
+++ b/test_interval_config.py
@@ -111,9 +111,11 @@ def test_interval_calculation():
     print("=" * 40)
     
     try:
-        from application.services.misbuffet.engine.misbuffet_engine import MisbuffetEngine
+        from application.services.misbuffet.engine.misbuffet_engine import MisbuffetEngine, MisbuffetEngineConfig
         
-        engine = MisbuffetEngine()
+        # Create engine with default configuration
+        engine_config = MisbuffetEngineConfig()
+        engine = MisbuffetEngine(engine_config)
         
         test_configs = [
             {"backtest_interval": "daily"},


### PR DESCRIPTION
Refactors MisbuffetEngine to follow DDD principles by:

- Replacing direct repository access with service layer
- Adding configuration support for different entity types
- Supporting company_shares, commodities, bonds, options, etc.
- Maintaining backward compatibility

Fixes #193

Generated with [Claude Code](https://claude.ai/code)