### PR TITLE
fix: implement missing abstract methods in BondRepository

### DIFF
--- a/src/infrastructure/repositories/local_repo/finance/financial_assets/bond_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/financial_assets/bond_repository.py
@@ -1,14 +1,70 @@
 from infrastructure.repositories.local_repo.finance.financial_assets.financial_asset_base_repository import FinancialAssetBaseRepository
 from src.infrastructure.models.finance.financial_assets.bond import Bond as Bond_Model
 from src.domain.entities.finance.financial_assets.bond import Bond as Bond_Entity
+from src.infrastructure.repositories.mappers.finance.financial_assets.bond_mapper import BondMapper
+from sqlalchemy.orm import Session
 
 class BondRepository(FinancialAssetBaseRepository):
+    def __init__(self, session: Session):
+        """Initialize BondRepository with database session."""
+        super().__init__(session)
+    
+    @property
+    def model_class(self):
+        """Return the SQLAlchemy model class for Bond."""
+        return Bond_Model
+    
+    def _to_entity(self, infra_bond: Bond_Model) -> Bond_Entity:
+        """Convert an infrastructure Bond to a domain Bond using mapper."""
+        if not infra_bond:
+            return None
+        return BondMapper.to_domain(infra_bond)
+    
+    def _to_model(self, entity: Bond_Entity) -> Bond_Model:
+        """Convert domain entity to ORM model."""
+        return BondMapper.to_orm(entity)
+    
+    def _to_domain(self, infra_bond: Bond_Model) -> Bond_Entity:
+        """Legacy method - delegates to _to_entity."""
+        return self._to_entity(infra_bond)
+    
     def get_by_id(self, id: int) -> Bond_Entity:
         """Fetches a Bond asset by its ID."""
         try:
-            return self.db.query(Bond_Model).filter(Bond_Model.id == id).first()
+            bond = self.session.query(Bond_Model).filter(Bond_Model.id == id).first()
+            return self._to_domain(bond)
         except Exception as e:
             print(f"Error retrieving bond by ID: {e}")
             return None
-        finally:
-            self.db.close()
+    
+    def get_by_isin(self, isin: str) -> Bond_Entity:
+        """Retrieve bond by ISIN."""
+        try:
+            bond = self.session.query(Bond_Model).filter(Bond_Model.isin == isin).first()
+            return self._to_domain(bond)
+        except Exception as e:
+            print(f"Error retrieving bond by ISIN {isin}: {e}")
+            return None
+    
+    def get_by_cusip(self, cusip: str) -> Bond_Entity:
+        """Retrieve bond by CUSIP."""
+        try:
+            bond = self.session.query(Bond_Model).filter(Bond_Model.cusip == cusip).first()
+            return self._to_domain(bond)
+        except Exception as e:
+            print(f"Error retrieving bond by CUSIP {cusip}: {e}")
+            return None
+    
+    def add(self, domain_bond: Bond_Entity) -> Bond_Entity:
+        """Add a new Bond record to the database."""
+        try:
+            # Convert domain entity to infrastructure model using mapper
+            new_bond = BondMapper.to_orm(domain_bond)
+            self.session.add(new_bond)
+            self.session.commit()
+            self.session.refresh(new_bond)
+            return self._to_domain(new_bond)
+        except Exception as e:
+            self.session.rollback()
+            print(f"Error adding bond: {e}")
+            return None

--- a/src/infrastructure/repositories/mappers/finance/financial_assets/__init__.py
+++ b/src/infrastructure/repositories/mappers/finance/financial_assets/__init__.py
@@ -1,1 +1,11 @@
 """Financial assets domain mappers."""
+
+from .company_share_mapper import CompanyShareMapper
+from .currency_mapper import CurrencyMapper
+from .bond_mapper import BondMapper
+
+__all__ = [
+    "CompanyShareMapper",
+    "CurrencyMapper", 
+    "BondMapper"
+]

--- a/src/infrastructure/repositories/mappers/finance/financial_assets/bond_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/financial_assets/bond_mapper.py
@@ -1,0 +1,93 @@
+"""
+Mapper for Bond domain entity and ORM model.
+Converts between domain entities and ORM models to avoid metaclass conflicts.
+"""
+
+from datetime import datetime, date
+from decimal import Decimal
+from typing import Optional, List, Dict, Any
+
+from src.domain.entities.finance.financial_assets.bond import Bond as DomainBond
+from src.infrastructure.models.finance.financial_assets.bond import Bond as ORMBond
+
+
+class BondMapper:
+    """Mapper for Bond domain entity and ORM model."""
+
+    @staticmethod
+    def to_domain(orm_obj: ORMBond) -> DomainBond:
+        """Convert ORM model to domain entity."""
+        if not orm_obj:
+            return None
+            
+        # Create domain entity
+        domain_entity = DomainBond(
+            cusip=orm_obj.cusip or orm_obj.isin,  # Use CUSIP or ISIN as identifier
+            issuer=orm_obj.issuer,
+            maturity_date=orm_obj.maturity_date,
+            coupon_rate=Decimal(str(orm_obj.coupon_rate)),
+            par_value=Decimal(str(orm_obj.face_value)) if orm_obj.face_value else Decimal('1000'),
+            bond_type=orm_obj.bond_type,
+            payment_frequency=orm_obj.payment_frequency or 2
+        )
+        
+        # Set additional properties if available
+        if orm_obj.current_price:
+            domain_entity._price = Decimal(str(orm_obj.current_price))
+            
+        if orm_obj.yield_to_maturity:
+            domain_entity._yield_to_maturity = Decimal(str(orm_obj.yield_to_maturity))
+            
+        if orm_obj.duration:
+            domain_entity._duration = Decimal(str(orm_obj.duration))
+            
+        if orm_obj.credit_rating:
+            domain_entity.update_credit_rating(orm_obj.credit_rating)
+        
+        return domain_entity
+
+    @staticmethod
+    def to_orm(domain_obj: DomainBond, orm_obj: Optional[ORMBond] = None) -> ORMBond:
+        """Convert domain entity to ORM model."""
+        if orm_obj is None:
+            orm_obj = ORMBond()
+        
+        # Map basic fields
+        orm_obj.isin = domain_obj.cusip  # Use CUSIP as ISIN for now
+        orm_obj.cusip = domain_obj.cusip
+        orm_obj.name = f"{domain_obj.issuer} Bond"
+        orm_obj.issuer = domain_obj.issuer
+        orm_obj.bond_type = domain_obj.bond_type
+        orm_obj.currency = 'USD'  # Default currency
+        
+        # Bond terms
+        orm_obj.face_value = domain_obj.par_value
+        orm_obj.coupon_rate = domain_obj.coupon_rate
+        orm_obj.issue_date = date.today()  # Default to today if not available
+        orm_obj.maturity_date = domain_obj.maturity_date
+        orm_obj.payment_frequency = domain_obj.payment_frequency
+        
+        # Credit information
+        if hasattr(domain_obj, 'credit_rating') and domain_obj.credit_rating:
+            orm_obj.credit_rating = domain_obj.credit_rating
+        
+        # Market data
+        if hasattr(domain_obj, '_price') and domain_obj._price:
+            orm_obj.current_price = domain_obj._price
+            
+        if hasattr(domain_obj, '_yield_to_maturity') and domain_obj._yield_to_maturity:
+            orm_obj.yield_to_maturity = domain_obj._yield_to_maturity
+            
+        if hasattr(domain_obj, '_duration') and domain_obj._duration:
+            orm_obj.duration = domain_obj._duration
+            
+        orm_obj.last_update = datetime.now()
+        orm_obj.is_tradeable = True
+        orm_obj.is_callable = False
+        
+        return orm_obj
+
+    @staticmethod
+    def to_infrastructure(domain_obj: DomainBond) -> ORMBond:
+        """Legacy method name for backward compatibility."""
+        return BondMapper.to_orm(domain_obj)


### PR DESCRIPTION
Implements missing abstract methods in BondRepository to fix instantiation error in MisbuffetEngine.

## Changes:
- Create BondMapper for proper entity-model conversions
- Implement missing abstract methods: model_class, _to_entity, _to_model
- Add proper Session-based constructor
- Add bond-specific methods: get_by_isin, get_by_cusip
- Update mapper exports to include BondMapper

Fixes 'Can't instantiate abstract class BondRepository without an implementation for abstract methods' error in MisbuffetEngine.

Fixes #193

🤖 Generated with [Claude Code](https://claude.ai/code)