### PR TITLE
fix: replace BatchNorm1d with LayerNorm in MLP model architecture

### DIFF
--- a/src/application/services/model_service/mlp_model_service.py
+++ b/src/application/services/model_service/mlp_model_service.py
@@ -48,7 +48,7 @@ class MLPModelService(ModelService):
                     for i, hidden_size in enumerate(hidden_layers):
                         layers.append(nn.Linear(prev_size, hidden_size))
                         if i < len(hidden_layers) - 1:  # Don't add activation after last hidden layer
-                            layers.append(nn.BatchNorm1d(hidden_size))
+                            layers.append(nn.LayerNorm(hidden_size))  # Use LayerNorm instead of BatchNorm1d
                             layers.append(nn.ReLU())
                         prev_size = hidden_size
                     
@@ -61,7 +61,7 @@ class MLPModelService(ModelService):
                     hidden_dim = int(input_size * mult)
                     self.network = nn.Sequential(
                         nn.Linear(input_size, hidden_dim),
-                        nn.BatchNorm1d(hidden_dim),
+                        nn.LayerNorm(hidden_dim),  # Use LayerNorm instead of BatchNorm1d
                         nn.Tanh(),
                         nn.Linear(hidden_dim, output_dim * timesteps)
                     )


### PR DESCRIPTION
Fixes MLP training error where BatchNorm expected more than 1 value per channel but received batch size of 1.

## Changes:
- Replace nn.BatchNorm1d with nn.LayerNorm in both configurable and original architectures
- Fix 'Expected more than 1 value per channel when training' error during spatiotemporal model training
- LayerNorm works with any batch size including single samples
- Maintains normalization benefits while supporting batch size = 1
- No breaking changes to model interface

Fixes #193

Generated with [Claude Code](https://claude.ai/code)