### PR TITLE
Implement 200-day moving average strategy for test_base_project_single

### DIFF
--- a/src/application/managers/project_managers/test_base_project_single/strategy/signal_generator.py
+++ b/src/application/managers/project_managers/test_base_project_single/strategy/signal_generator.py
@@ -1,5 +1,5 @@
 """
-ML-based signal generation for trading strategies.
+Simple 200-day moving average signal generation for trading strategies.
 """
 
 import pandas as pd
@@ -7,27 +7,68 @@ import numpy as np
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 
-from ..models.spatiotemporal_model import HybridSpatiotemporalModel
 from ..config import DEFAULT_CONFIG
 
 
-class MLSignalGenerator:
-    """Generates trading signals from ML models and factor data."""
+class SimpleSignalGenerator:
+    """Generates simple binary trading signals from 200-day moving averages."""
     
-    def __init__(self, trained_model: HybridSpatiotemporalModel):
-        self.trained_model = trained_model
+    def __init__(self, moving_average_window: int = 200):
+        self.moving_average_window = moving_average_window
         self.config = DEFAULT_CONFIG
     
     def generate_trading_signals(self,
-                               factor_data: pd.DataFrame,
-                               confidence_threshold: float = 0.6) -> pd.DataFrame:
-        """Generate trading signals from factor data."""
-        return self.trained_model.generate_signals_from_factors(
-            factor_data, model_type='ensemble', confidence_threshold=confidence_threshold
-        )
+                               price_data: pd.DataFrame,
+                               price_column: str = 'close') -> Dict[str, int]:
+        """Generate trading signals from price data using 200-day moving average.
+        
+        Args:
+            price_data: DataFrame with price data
+            price_column: Column name containing price data
+            
+        Returns:
+            Dictionary with ticker -> signal mapping (1=long, -1=short)
+        """
+        signals = {}
+        
+        if price_column not in price_data.columns:
+            return signals
+            
+        # Calculate 200-day moving average
+        price_data['ma_200'] = price_data[price_column].rolling(window=self.moving_average_window).mean()
+        
+        # Generate signals: 1 if price > MA, -1 if price < MA
+        latest_price = price_data[price_column].iloc[-1]
+        latest_ma = price_data['ma_200'].iloc[-1]
+        
+        if pd.notna(latest_ma) and pd.notna(latest_price):
+            signal = 1 if latest_price > latest_ma else -1
+            # Assuming single ticker data - use a generic key or extract from data
+            signals['signal'] = signal
+            
+        return signals
     
-    def get_signal_confidence(self, signals: pd.DataFrame) -> Dict[str, float]:
-        """Extract signal confidence scores."""
-        if 'confidence' in signals.columns:
-            return signals['confidence'].to_dict()
-        return {idx: 0.5 for idx in signals.index}  # Default confidence
+    def get_signal_confidence(self, signals: Dict[str, int]) -> Dict[str, float]:
+        """Get signal confidence - always 1.0 for simple binary signals."""
+        return {ticker: 1.0 for ticker in signals.keys()}
+    
+    def calculate_200_day_average(self, prices: pd.Series) -> float:
+        """Calculate 200-day simple moving average."""
+        if len(prices) < self.moving_average_window:
+            return np.nan
+        return prices.tail(self.moving_average_window).mean()
+    
+    def generate_signal_for_ticker(self, current_price: float, moving_average: float) -> int:
+        """Generate binary signal for a single ticker.
+        
+        Args:
+            current_price: Current closing price
+            moving_average: 200-day moving average
+            
+        Returns:
+            1 for long, -1 for short
+        """
+        if pd.isna(current_price) or pd.isna(moving_average):
+            return 0  # No signal if data is missing
+        
+        return 1 if current_price > moving_average else -1


### PR DESCRIPTION
Implements the simple 200-day moving average trading algorithm as documented in the CLAUDE.md file.

## Changes
- Simplified BaseProjectAlgorithm to use 200-day MA signals instead of complex ML models
- Updated SimpleSignalGenerator for binary signal calculation
- Modified SimpleMomentumStrategy for straightforward trend-following
- Updated TestBaseProjectManager to coordinate simple components
- Long when price > 200-day average, short when price < 200-day average
- Maintains factor creation system and Misbuffet backtesting integration

Fixes #211

🤖 Generated with [Claude Code](https://claude.ai/code)