### PR TITLE
fix: Update Country and Industry models for SQL Server compatibility

### DIFF
--- a/src/infrastructure/models/country.py
+++ b/src/infrastructure/models/country.py
@@ -9,9 +9,9 @@ class Country(Base):
     __tablename__ = 'countries'
     
     id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String, nullable=False, unique=True)
+    name = Column(String(255), nullable=False, unique=True)
     iso_code = Column(String(3), nullable=False, unique=True)  # e.g., 'USA', 'CAN'
-    region = Column(String, nullable=True)  # Optional region classification (e.g., 'North America')
+    region = Column(String(255), nullable=True)  # Optional region classification (e.g., 'North America')
     continent_id = Column(Integer, ForeignKey("continents.id"), nullable=True)
     
     # Relationships

--- a/src/infrastructure/models/industry.py
+++ b/src/infrastructure/models/industry.py
@@ -6,8 +6,8 @@ class Industry(Base):
     __tablename__ = 'industries'
     
     id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String, nullable=False, unique=True)
-    description = Column(String, nullable=True)  # Optional description for the industry
+    name = Column(String(255), nullable=False, unique=True)
+    description = Column(String(1000), nullable=True)  # Optional description for the industry
     sector_id = Column(Integer, ForeignKey('sectors.id'), nullable=False)  # Foreign key for related Sector
     
     # Relationships


### PR DESCRIPTION
Fixes SQL Server VARCHAR(max) unique constraint error by limiting string lengths in Country and Industry models.

## Changes:
- Country.name: String → String(255)
- Country.region: String → String(255)
- Industry.name: String → String(255)
- Industry.description: String → String(1000)

Closes #215

🤖 Generated with [Claude Code](https://claude.ai/code)