### PR TITLE
Simplify portfolio entities to basic identification and dates

### DIFF
--- a/src/domain/entities/finance/financial_assets/derivatives/option/portfolio_company_share_option.py
+++ b/src/domain/entities/finance/financial_assets/derivatives/option/portfolio_company_share_option.py
@@ -1,7 +1,7 @@
 from datetime import date
-from optparse import Option
 from typing import Optional
 
+from domain.entities.finance.financial_assets.derivatives.option.option import Option
 from domain.entities.finance.financial_assets.derivatives.option.option_type import OptionType
 from domain.entities.finance.portfolio.portfolio_company_share import PortfolioCompanyShare
 

--- a/src/infrastructure/models/finance/financial_assets/portfolio_company_share_option.py
+++ b/src/infrastructure/models/finance/financial_assets/portfolio_company_share_option.py
@@ -1,0 +1,34 @@
+"""
+Infrastructure model for portfolio company share options - SQLAlchemy model matching domain entity
+"""
+from datetime import date
+from typing import Optional
+
+from sqlalchemy import Column, Integer, Date, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+from src.infrastructure.models.base import Base
+
+
+class PortfolioCompanyShareOptionModel(Base):
+    """
+    SQLAlchemy model for portfolio company share options.
+    Maps to domain.entities.finance.financial_assets.derivatives.option.portfolio_company_share_option.PortfolioCompanyShareOption
+    
+    Contains only basic identification and date parameters as requested.
+    """
+    __tablename__ = 'portfolio_company_share_options'
+
+    id = Column(Integer, primary_key=True)
+    underlying_id = Column(Integer, ForeignKey('portfolio_company_shares.id'), nullable=False)
+    company_id = Column(Integer, ForeignKey('companies.id'), nullable=False)
+    expiration_date = Column(Date, nullable=False)
+    option_type = Column(String(10), nullable=False)  # 'CALL' or 'PUT'
+    exercise_style = Column(String(20), nullable=False)
+    strike_id = Column(Integer, nullable=True)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=True)
+
+    # Relationships
+    underlying = relationship("PortfolioCompanyShareModel")
+    company = relationship("CompanyModel")

--- a/src/infrastructure/models/finance/holding.py
+++ b/src/infrastructure/models/finance/holding.py
@@ -1,0 +1,57 @@
+"""
+Infrastructure models for holdings - SQLAlchemy models matching domain entities
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, Integer, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+
+from src.infrastructure.models.base import Base
+
+
+class HoldingModel(Base):
+    """
+    Base SQLAlchemy model for holdings.
+    Maps to domain.entities.finance.holding.holding.Holding
+    """
+    __tablename__ = 'holdings'
+
+    id = Column(Integer, primary_key=True)
+    asset_id = Column(Integer, ForeignKey('financial_assets.id'), nullable=False)
+    container_id = Column(Integer, nullable=False)
+    start_date = Column(DateTime, nullable=False)
+    end_date = Column(DateTime, nullable=True)
+
+    # Relationships
+    asset = relationship("FinancialAssetModel", back_populates="holdings")
+
+
+class PortfolioHoldingModel(HoldingModel):
+    """
+    SQLAlchemy model for portfolio holdings.
+    Maps to domain.entities.finance.holding.portfolio_holding.PortfolioHolding
+    """
+    __tablename__ = 'portfolio_holdings'
+    
+    id = Column(Integer, ForeignKey('holdings.id'), primary_key=True)
+    portfolio_id = Column(Integer, ForeignKey('portfolios.id'), nullable=False)
+
+    # Relationships
+    portfolio = relationship("PortfolioModel", back_populates="holdings")
+
+
+class PortfolioCompanyShareHoldingModel(PortfolioHoldingModel):
+    """
+    SQLAlchemy model for company share holdings within a portfolio.
+    Maps to domain.entities.finance.holding.portfolio_company_share_holding.PortfolioCompanyShareHolding
+    """
+    __tablename__ = 'portfolio_company_share_holdings'
+    
+    id = Column(Integer, ForeignKey('portfolio_holdings.id'), primary_key=True)
+    company_share_id = Column(Integer, ForeignKey('company_shares.id'), nullable=False)
+    portfolio_company_share_id = Column(Integer, ForeignKey('portfolio_company_shares.id'), nullable=False)
+
+    # Relationships
+    company_share = relationship("CompanyShareModel")
+    portfolio_company_share = relationship("PortfolioCompanyShareModel")

--- a/src/infrastructure/repositories/local_repo/finance/financial_assets/portfolio_company_share_option_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/financial_assets/portfolio_company_share_option_repository.py
@@ -1,0 +1,79 @@
+"""
+Repository for portfolio company share option entities
+"""
+from typing import List, Optional
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from src.infrastructure.models.finance.financial_assets.portfolio_company_share_option import PortfolioCompanyShareOptionModel
+from src.infrastructure.repositories.mappers.finance.portfolio_company_share_option_mapper import PortfolioCompanyShareOptionMapper
+from src.domain.entities.finance.financial_assets.derivatives.option.portfolio_company_share_option import PortfolioCompanyShareOption
+
+
+class PortfolioCompanyShareOptionRepository:
+    """Repository for portfolio company share option entities with basic CRUD operations"""
+    
+    def __init__(self, session: Session):
+        self.session = session
+        self.mapper = PortfolioCompanyShareOptionMapper()
+
+    def get_by_id(self, option_id: int) -> Optional[PortfolioCompanyShareOption]:
+        """Get an option by ID"""
+        model = self.session.query(PortfolioCompanyShareOptionModel).filter_by(id=option_id).first()
+        return self.mapper.to_entity(model) if model else None
+
+    def get_all(self) -> List[PortfolioCompanyShareOption]:
+        """Get all options"""
+        models = self.session.query(PortfolioCompanyShareOptionModel).all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def get_by_underlying_id(self, underlying_id: int) -> List[PortfolioCompanyShareOption]:
+        """Get all options for a specific underlying asset"""
+        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(underlying_id=underlying_id).all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def get_by_company_id(self, company_id: int) -> List[PortfolioCompanyShareOption]:
+        """Get all options for a specific company"""
+        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(company_id=company_id).all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def get_by_expiration_date(self, expiration_date: date) -> List[PortfolioCompanyShareOption]:
+        """Get all options expiring on a specific date"""
+        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(expiration_date=expiration_date).all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def get_active_options(self, company_id: int = None) -> List[PortfolioCompanyShareOption]:
+        """Get active options (no end_date or end_date in future)"""
+        from datetime import datetime
+        query = self.session.query(PortfolioCompanyShareOptionModel).filter(
+            (PortfolioCompanyShareOptionModel.end_date.is_(None)) | 
+            (PortfolioCompanyShareOptionModel.end_date > date.today())
+        )
+        if company_id:
+            query = query.filter_by(company_id=company_id)
+        
+        models = query.all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def get_by_option_type(self, option_type: str) -> List[PortfolioCompanyShareOption]:
+        """Get options by type (CALL or PUT)"""
+        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(option_type=option_type).all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def save(self, option: PortfolioCompanyShareOption) -> PortfolioCompanyShareOption:
+        """Save or update an option"""
+        model = self.mapper.to_model(option)
+        self.session.merge(model)
+        self.session.commit()
+        self.session.refresh(model)
+        return self.mapper.to_entity(model)
+
+    def delete(self, option_id: int) -> bool:
+        """Delete an option by ID"""
+        model = self.session.query(PortfolioCompanyShareOptionModel).filter_by(id=option_id).first()
+        if model:
+            self.session.delete(model)
+            self.session.commit()
+            return True
+        return False

--- a/src/infrastructure/repositories/local_repo/finance/holding_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/holding_repository.py
@@ -1,0 +1,122 @@
+"""
+Repository for holding entities
+"""
+from typing import List, Optional
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from src.infrastructure.models.finance.holding import (
+    HoldingModel, 
+    PortfolioHoldingModel, 
+    PortfolioCompanyShareHoldingModel
+)
+from src.infrastructure.repositories.mappers.finance.holding_mapper import HoldingMapper
+from src.domain.entities.finance.holding.holding import Holding
+from src.domain.entities.finance.holding.portfolio_holding import PortfolioHolding
+from src.domain.entities.finance.holding.portfolio_company_share_holding import PortfolioCompanyShareHolding
+
+
+class HoldingRepository:
+    """Repository for holding entities with basic CRUD operations"""
+    
+    def __init__(self, session: Session):
+        self.session = session
+        self.mapper = HoldingMapper()
+
+    def get_by_id(self, holding_id: int) -> Optional[Holding]:
+        """Get a holding by ID"""
+        model = self.session.query(HoldingModel).filter_by(id=holding_id).first()
+        return self.mapper.to_entity(model) if model else None
+
+    def get_all(self) -> List[Holding]:
+        """Get all holdings"""
+        models = self.session.query(HoldingModel).all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def get_by_container_id(self, container_id: int) -> List[Holding]:
+        """Get all holdings for a specific container"""
+        models = self.session.query(HoldingModel).filter_by(container_id=container_id).all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def get_active_holdings(self, container_id: int = None) -> List[Holding]:
+        """Get active holdings (no end_date or end_date in future)"""
+        query = self.session.query(HoldingModel).filter(
+            (HoldingModel.end_date.is_(None)) | (HoldingModel.end_date > datetime.now())
+        )
+        if container_id:
+            query = query.filter_by(container_id=container_id)
+        
+        models = query.all()
+        return [self.mapper.to_entity(model) for model in models]
+
+    def save(self, holding: Holding) -> Holding:
+        """Save or update a holding"""
+        model = self.mapper.to_model(holding)
+        self.session.merge(model)
+        self.session.commit()
+        self.session.refresh(model)
+        return self.mapper.to_entity(model)
+
+    def delete(self, holding_id: int) -> bool:
+        """Delete a holding by ID"""
+        model = self.session.query(HoldingModel).filter_by(id=holding_id).first()
+        if model:
+            self.session.delete(model)
+            self.session.commit()
+            return True
+        return False
+
+
+class PortfolioHoldingRepository:
+    """Repository for portfolio holding entities"""
+    
+    def __init__(self, session: Session):
+        self.session = session
+        self.mapper = HoldingMapper()
+
+    def get_by_id(self, holding_id: int) -> Optional[PortfolioHolding]:
+        """Get a portfolio holding by ID"""
+        model = self.session.query(PortfolioHoldingModel).filter_by(id=holding_id).first()
+        return self.mapper.portfolio_holding_to_entity(model) if model else None
+
+    def get_by_portfolio_id(self, portfolio_id: int) -> List[PortfolioHolding]:
+        """Get all holdings for a specific portfolio"""
+        models = self.session.query(PortfolioHoldingModel).filter_by(portfolio_id=portfolio_id).all()
+        return [self.mapper.portfolio_holding_to_entity(model) for model in models]
+
+    def save(self, holding: PortfolioHolding) -> PortfolioHolding:
+        """Save or update a portfolio holding"""
+        model = self.mapper.portfolio_holding_to_model(holding)
+        self.session.merge(model)
+        self.session.commit()
+        self.session.refresh(model)
+        return self.mapper.portfolio_holding_to_entity(model)
+
+
+class PortfolioCompanyShareHoldingRepository:
+    """Repository for portfolio company share holding entities"""
+    
+    def __init__(self, session: Session):
+        self.session = session
+        self.mapper = HoldingMapper()
+
+    def get_by_id(self, holding_id: int) -> Optional[PortfolioCompanyShareHolding]:
+        """Get a portfolio company share holding by ID"""
+        model = self.session.query(PortfolioCompanyShareHoldingModel).filter_by(id=holding_id).first()
+        return self.mapper.portfolio_company_share_holding_to_entity(model) if model else None
+
+    def get_by_portfolio_company_share_id(self, portfolio_id: int) -> List[PortfolioCompanyShareHolding]:
+        """Get all company share holdings for a specific portfolio company share"""
+        models = self.session.query(PortfolioCompanyShareHoldingModel).filter_by(
+            portfolio_company_share_id=portfolio_id
+        ).all()
+        return [self.mapper.portfolio_company_share_holding_to_entity(model) for model in models]
+
+    def save(self, holding: PortfolioCompanyShareHolding) -> PortfolioCompanyShareHolding:
+        """Save or update a portfolio company share holding"""
+        model = self.mapper.portfolio_company_share_holding_to_model(holding)
+        self.session.merge(model)
+        self.session.commit()
+        self.session.refresh(model)
+        return self.mapper.portfolio_company_share_holding_to_entity(model)

--- a/src/infrastructure/repositories/mappers/finance/holding_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/holding_mapper.py
@@ -1,0 +1,118 @@
+"""
+Mappers for converting between holding domain entities and infrastructure models
+"""
+from typing import Optional
+
+from src.domain.entities.finance.holding.holding import Holding
+from src.domain.entities.finance.holding.portfolio_holding import PortfolioHolding
+from src.domain.entities.finance.holding.portfolio_company_share_holding import PortfolioCompanyShareHolding
+from src.infrastructure.models.finance.holding import (
+    HoldingModel,
+    PortfolioHoldingModel,
+    PortfolioCompanyShareHoldingModel
+)
+
+
+class HoldingMapper:
+    """Mapper for converting between holding entities and models"""
+
+    def to_entity(self, model: Optional[HoldingModel]) -> Optional[Holding]:
+        """Convert HoldingModel to Holding entity"""
+        if not model:
+            return None
+
+        # For now, we'll use a simplified approach where asset is just referenced by ID
+        # In a full implementation, you'd load the actual asset entity
+        from src.domain.entities.finance.financial_assets.financial_asset import FinancialAsset
+        
+        # Create a placeholder FinancialAsset - in real implementation you'd load from repository
+        asset = FinancialAsset(id=model.asset_id, start_date=model.start_date.date(), end_date=model.end_date.date() if model.end_date else None)
+
+        return Holding(
+            id=model.id,
+            asset=asset,
+            container_id=model.container_id,
+            start_date=model.start_date,
+            end_date=model.end_date
+        )
+
+    def to_model(self, entity: Holding) -> HoldingModel:
+        """Convert Holding entity to HoldingModel"""
+        return HoldingModel(
+            id=entity.id,
+            asset_id=entity.asset.id,
+            container_id=entity.container_id,
+            start_date=entity.start_date,
+            end_date=entity.end_date
+        )
+
+    def portfolio_holding_to_entity(self, model: Optional[PortfolioHoldingModel]) -> Optional[PortfolioHolding]:
+        """Convert PortfolioHoldingModel to PortfolioHolding entity"""
+        if not model:
+            return None
+
+        # Create base holding first
+        base_holding = self.to_entity(model)
+        if not base_holding:
+            return None
+
+        return PortfolioHolding(
+            id=base_holding.id,
+            asset=base_holding.asset,
+            container_id=base_holding.container_id,
+            start_date=base_holding.start_date,
+            end_date=base_holding.end_date
+        )
+
+    def portfolio_holding_to_model(self, entity: PortfolioHolding) -> PortfolioHoldingModel:
+        """Convert PortfolioHolding entity to PortfolioHoldingModel"""
+        return PortfolioHoldingModel(
+            id=entity.id,
+            asset_id=entity.asset.id,
+            container_id=entity.container_id,
+            portfolio_id=entity.container_id,  # Assuming container_id is portfolio_id
+            start_date=entity.start_date,
+            end_date=entity.end_date
+        )
+
+    def portfolio_company_share_holding_to_entity(self, model: Optional[PortfolioCompanyShareHoldingModel]) -> Optional[PortfolioCompanyShareHolding]:
+        """Convert PortfolioCompanyShareHoldingModel to PortfolioCompanyShareHolding entity"""
+        if not model:
+            return None
+
+        # Create placeholder objects - in real implementation you'd load from repositories
+        from src.domain.entities.finance.financial_assets.share.company_share.company_share import CompanyShare
+        from src.domain.entities.finance.portfolio.portfolio_company_share import PortfolioCompanyShare
+
+        company_share = CompanyShare(
+            id=model.company_share_id,
+            start_date=model.start_date.date(),
+            end_date=model.end_date.date() if model.end_date else None
+        )
+        
+        portfolio = PortfolioCompanyShare(
+            id=model.portfolio_company_share_id,
+            start_date=model.start_date.date(),
+            end_date=model.end_date.date() if model.end_date else None
+        )
+
+        return PortfolioCompanyShareHolding(
+            id=model.id,
+            asset=company_share,
+            portfolio=portfolio,
+            start_date=model.start_date,
+            end_date=model.end_date
+        )
+
+    def portfolio_company_share_holding_to_model(self, entity: PortfolioCompanyShareHolding) -> PortfolioCompanyShareHoldingModel:
+        """Convert PortfolioCompanyShareHolding entity to PortfolioCompanyShareHoldingModel"""
+        return PortfolioCompanyShareHoldingModel(
+            id=entity.id,
+            asset_id=entity.asset.id,
+            container_id=entity.container_id,
+            portfolio_id=entity.portfolio.id,
+            company_share_id=entity.asset.id,
+            portfolio_company_share_id=entity.portfolio.id,
+            start_date=entity.start_date,
+            end_date=entity.end_date
+        )

--- a/src/infrastructure/repositories/mappers/finance/portfolio_company_share_option_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/portfolio_company_share_option_mapper.py
@@ -1,0 +1,55 @@
+"""
+Mapper for converting between portfolio company share option domain entities and infrastructure models
+"""
+from typing import Optional
+
+from src.domain.entities.finance.financial_assets.derivatives.option.portfolio_company_share_option import PortfolioCompanyShareOption
+from src.infrastructure.models.finance.financial_assets.portfolio_company_share_option import PortfolioCompanyShareOptionModel
+from src.domain.entities.finance.financial_assets.derivatives.option.option_type import OptionType
+
+
+class PortfolioCompanyShareOptionMapper:
+    """Mapper for converting between option entities and models"""
+
+    def to_entity(self, model: Optional[PortfolioCompanyShareOptionModel]) -> Optional[PortfolioCompanyShareOption]:
+        """Convert PortfolioCompanyShareOptionModel to PortfolioCompanyShareOption entity"""
+        if not model:
+            return None
+
+        # Create placeholder underlying - in real implementation you'd load from repository
+        from src.domain.entities.finance.portfolio.portfolio_company_share import PortfolioCompanyShare
+        
+        underlying = PortfolioCompanyShare(
+            id=model.underlying_id,
+            start_date=model.start_date,
+            end_date=model.end_date
+        )
+
+        # Convert string to OptionType enum
+        option_type = OptionType.CALL if model.option_type.upper() == 'CALL' else OptionType.PUT
+
+        return PortfolioCompanyShareOption(
+            id=model.id,
+            underlying=underlying,
+            company_id=model.company_id,
+            expiration_date=model.expiration_date,
+            option_type=option_type,
+            exercise_style=model.exercise_style,
+            strike_id=model.strike_id,
+            start_date=model.start_date,
+            end_date=model.end_date
+        )
+
+    def to_model(self, entity: PortfolioCompanyShareOption) -> PortfolioCompanyShareOptionModel:
+        """Convert PortfolioCompanyShareOption entity to PortfolioCompanyShareOptionModel"""
+        return PortfolioCompanyShareOptionModel(
+            id=entity.id,
+            underlying_id=entity.underlying.id,
+            company_id=entity.company_id,
+            expiration_date=entity.expiration_date,
+            option_type=entity.option_type.value,  # Convert enum to string
+            exercise_style=entity.exercise_style,
+            strike_id=entity.strike_id,
+            start_date=entity.start_date,
+            end_date=entity.end_date
+        )


### PR DESCRIPTION
This PR simplifies the portfolio entities implementation as requested in issue #240

## Changes:
- Fixed portfolio_company_share_option.py import from optparse to domain Option
- Created simplified infrastructure models for holdings and options
- Added basic holding models with only ID, dates, and relationships
- Added portfolio company share option model with only identification parameters
- Created repositories with CRUD operations for simplified entities
- Added mappers for entity-model conversion with proper type handling
- Removed all financial factors, Greeks, market data, and position information

Generated with [Claude Code](https://claude.ai/code)