### PR TITLE
fix: Resolve circular import issues in misbuffet service

### DIFF
--- a/import_analysis.py
+++ b/import_analysis.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Static analysis of potential circular import issues in the misbuffet service.
+This script analyzes import patterns to identify circular dependencies.
+"""
+
+import ast
+import os
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+class ImportAnalyzer:
+    """Analyzes Python files for import patterns and circular dependencies."""
+    
+    def __init__(self, root_path: str):
+        self.root_path = Path(root_path)
+        self.import_graph: Dict[str, Set[str]] = {}
+        self.module_files: Dict[str, Path] = {}
+        
+    def analyze_misbuffet_imports(self) -> Dict[str, any]:
+        """Analyze imports in the misbuffet service directory."""
+        misbuffet_path = self.root_path / "src" / "application" / "services" / "misbuffet"
+        
+        if not misbuffet_path.exists():
+            return {"error": "Misbuffet directory not found"}
+        
+        # Scan all Python files
+        python_files = list(misbuffet_path.rglob("*.py"))
+        
+        results = {
+            "total_files": len(python_files),
+            "import_patterns": {},
+            "potential_issues": [],
+            "key_modules": {}
+        }
+        
+        # Analyze each file
+        for file_path in python_files:
+            try:
+                relative_path = file_path.relative_to(self.root_path)
+                module_name = str(relative_path).replace("/", ".").replace(".py", "")
+                
+                imports = self._extract_imports(file_path)
+                self.import_graph[module_name] = set(imports)
+                self.module_files[module_name] = file_path
+                
+                results["import_patterns"][module_name] = imports
+                
+                # Check for potentially problematic patterns
+                if any(".." in imp for imp in imports):
+                    results["potential_issues"].append({
+                        "file": str(relative_path),
+                        "issue": "Relative imports detected",
+                        "imports": [imp for imp in imports if ".." in imp]
+                    })
+                    
+            except Exception as e:
+                results["potential_issues"].append({
+                    "file": str(file_path),
+                    "issue": f"Analysis error: {e}",
+                    "imports": []
+                })
+        
+        # Analyze key modules
+        key_modules = [
+            "src.application.services.misbuffet.common.time_utils",
+            "src.application.services.misbuffet.common.__init__",
+            "src.application.services.misbuffet.__init__",
+            "src.application.services.misbuffet.brokers.base_broker",
+            "src.application.services.misbuffet.brokers.__init__",
+            "src.application.services.misbuffet.algorithm.__init__"
+        ]
+        
+        for module in key_modules:
+            if module in self.import_graph:
+                results["key_modules"][module] = {
+                    "imports": list(self.import_graph[module]),
+                    "import_count": len(self.import_graph[module])
+                }
+        
+        # Detect potential circular imports
+        cycles = self._detect_cycles()
+        if cycles:
+            results["circular_imports"] = cycles
+        
+        return results
+    
+    def _extract_imports(self, file_path: Path) -> List[str]:
+        """Extract import statements from a Python file."""
+        imports = []
+        
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+                
+            tree = ast.parse(content)
+            
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        imports.append(alias.name)
+                elif isinstance(node, ast.ImportFrom):
+                    if node.module:
+                        if node.level > 0:  # Relative import
+                            imports.append("." * node.level + (node.module or ""))
+                        else:
+                            imports.append(node.module)
+                        
+        except Exception:
+            # If parsing fails, try simple text analysis
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    lines = f.readlines()
+                
+                for line in lines:
+                    line = line.strip()
+                    if line.startswith('import ') or line.startswith('from '):
+                        if '#' in line:
+                            line = line[:line.index('#')]
+                        imports.append(line.strip())
+                        
+            except Exception:
+                pass
+        
+        return imports
+    
+    def _detect_cycles(self) -> List[List[str]]:
+        """Detect circular import cycles using DFS."""
+        visited = set()
+        rec_stack = set()
+        cycles = []
+        
+        def dfs(node: str, path: List[str]) -> bool:
+            if node in rec_stack:
+                # Found a cycle
+                cycle_start = path.index(node)
+                cycle = path[cycle_start:] + [node]
+                cycles.append(cycle)
+                return True
+            
+            if node in visited:
+                return False
+                
+            visited.add(node)
+            rec_stack.add(node)
+            
+            # Get dependencies for this module
+            dependencies = self.import_graph.get(node, set())
+            
+            for dep in dependencies:
+                if dep.startswith('.'):
+                    # Convert relative imports to absolute
+                    parts = node.split('.')
+                    level = len(dep) - len(dep.lstrip('.'))
+                    if level <= len(parts):
+                        base_parts = parts[:-level] if level > 0 else parts
+                        dep_module = '.'.join(base_parts + dep.lstrip('.').split('.')) if dep.lstrip('.') else '.'.join(base_parts)
+                    else:
+                        continue
+                else:
+                    dep_module = dep
+                
+                if dep_module in self.import_graph:
+                    if dfs(dep_module, path + [node]):
+                        return True
+            
+            rec_stack.remove(node)
+            return False
+        
+        for module in self.import_graph:
+            if module not in visited:
+                dfs(module, [])
+        
+        return cycles
+
+def main():
+    """Run the import analysis."""
+    print("=" * 70)
+    print("MISBUFFET SERVICE IMPORT ANALYSIS")
+    print("=" * 70)
+    
+    analyzer = ImportAnalyzer("/home/runner/work/base_infrastructure/base_infrastructure")
+    results = analyzer.analyze_misbuffet_imports()
+    
+    if "error" in results:
+        print(f"Error: {results['error']}")
+        return
+    
+    print(f"Total Python files analyzed: {results['total_files']}")
+    
+    # Show key modules
+    print("\nKEY MODULES:")
+    print("-" * 40)
+    for module, info in results.get("key_modules", {}).items():
+        print(f"{module}")
+        print(f"  Imports: {info['import_count']}")
+        if info['imports']:
+            for imp in info['imports'][:5]:  # Show first 5 imports
+                print(f"    - {imp}")
+            if len(info['imports']) > 5:
+                print(f"    ... and {len(info['imports']) - 5} more")
+        print()
+    
+    # Show potential issues
+    if results.get("potential_issues"):
+        print("POTENTIAL ISSUES:")
+        print("-" * 40)
+        for issue in results["potential_issues"][:10]:  # Show first 10 issues
+            print(f"File: {issue['file']}")
+            print(f"Issue: {issue['issue']}")
+            if issue['imports']:
+                print(f"Problematic imports: {issue['imports']}")
+            print()
+    
+    # Show circular imports if detected
+    if results.get("circular_imports"):
+        print("CIRCULAR IMPORT CYCLES DETECTED:")
+        print("-" * 40)
+        for i, cycle in enumerate(results["circular_imports"], 1):
+            print(f"Cycle {i}: {' → '.join(cycle)}")
+        print()
+    else:
+        print("No obvious circular import cycles detected in static analysis.")
+    
+    # Recommendations
+    print("RECOMMENDATIONS:")
+    print("-" * 40)
+    
+    if results.get("potential_issues"):
+        relative_imports = [issue for issue in results["potential_issues"] 
+                          if "Relative imports" in issue['issue']]
+        if relative_imports:
+            print("1. Consider converting relative imports to absolute imports")
+            print("   Relative imports can sometimes cause circular import issues")
+    
+    print("2. To test actual imports, run the following manually:")
+    print("   python -c \"from src.application.services.misbuffet.common.time_utils import Time; print('Time import works')\"")
+    print("   python -c \"import src.application.services.misbuffet; print('Main misbuffet import works')\"")
+    print("   python -c \"from src.application.services.misbuffet.brokers.base_broker import BaseBroker; print('BaseBroker import works')\"")
+    
+    print("\n3. If imports fail, check for:")
+    print("   - Missing __init__.py files")
+    print("   - Incorrect relative import paths")  
+    print("   - Actual circular dependencies at runtime")
+
+if __name__ == "__main__":
+    main()

--- a/simple_import_test.py
+++ b/simple_import_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Simple import test for misbuffet circular import fixes."""
+
+import sys
+import os
+
+# Add the current directory to sys.path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+def test_time_import():
+    """Test Time import from time_utils."""
+    try:
+        print("Testing: from src.application.services.misbuffet.common.time_utils import Time")
+        from src.application.services.misbuffet.common.time_utils import Time
+        print("✓ SUCCESS: Time import successful")
+        
+        # Test basic functionality
+        time_instance = Time()
+        current_time = time_instance.now()
+        print(f"  Time instance created, current time: {current_time}")
+        return True
+    except Exception as e:
+        print(f"✗ FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_misbuffet_import():
+    """Test main misbuffet module import."""
+    try:
+        print("\nTesting: import src.application.services.misbuffet")
+        import src.application.services.misbuffet
+        print("✓ SUCCESS: Main misbuffet module import successful")
+        return True
+    except Exception as e:
+        print(f"✗ FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_base_broker_import():
+    """Test base broker import."""
+    try:
+        print("\nTesting: from src.application.services.misbuffet.brokers.base_broker import BaseBroker")
+        from src.application.services.misbuffet.brokers.base_broker import BaseBroker
+        print("✓ SUCCESS: BaseBroker import successful")
+        return True
+    except Exception as e:
+        print(f"✗ FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_broker_factory_import():
+    """Test broker factory import."""
+    try:
+        print("\nTesting: from src.application.services.misbuffet.brokers.broker_factory import BrokerFactory")
+        from src.application.services.misbuffet.brokers.broker_factory import BrokerFactory
+        print("✓ SUCCESS: BrokerFactory import successful")
+        return True
+    except Exception as e:
+        print(f"✗ FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_ibkr_broker_import():
+    """Test IBKR broker import."""
+    try:
+        print("\nTesting: from src.application.services.misbuffet.brokers.ibkr.interactive_brokers_broker import InteractiveBrokersBroker")
+        from src.application.services.misbuffet.brokers.ibkr.interactive_brokers_broker import InteractiveBrokersBroker
+        print("✓ SUCCESS: InteractiveBrokersBroker import successful")
+        return True
+    except Exception as e:
+        print(f"✗ FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def main():
+    """Run all import tests."""
+    print("=" * 70)
+    print("TESTING CIRCULAR IMPORT FIXES FOR MISBUFFET SERVICE")
+    print("=" * 70)
+    
+    results = []
+    
+    # Test 1: Time import
+    results.append(("Time from time_utils", test_time_import()))
+    
+    # Test 2: Main misbuffet module
+    results.append(("Main misbuffet module", test_misbuffet_import()))
+    
+    # Test 3: Broker imports
+    results.append(("Base broker", test_base_broker_import()))
+    results.append(("Broker factory", test_broker_factory_import()))
+    results.append(("IBKR broker", test_ibkr_broker_import()))
+    
+    # Summary
+    print("\n" + "=" * 70)
+    print("SUMMARY")
+    print("=" * 70)
+    
+    passed = 0
+    for test_name, result in results:
+        status = "PASS" if result else "FAIL"
+        print(f"{status}: {test_name}")
+        if result:
+            passed += 1
+    
+    failed = len(results) - passed
+    print(f"\nResults: {passed}/{len(results)} tests passed, {failed} failed")
+    
+    if failed == 0:
+        print("\n🎉 All imports working! Circular import issues appear to be resolved.")
+    else:
+        print(f"\n⚠️ {failed} import(s) still need fixing.")
+    
+    return failed
+
+if __name__ == "__main__":
+    exit_code = main()
+    sys.exit(exit_code)

--- a/src/application/services/misbuffet/brokers/base_broker.py
+++ b/src/application/services/misbuffet/brokers/base_broker.py
@@ -12,8 +12,8 @@ from enum import Enum
 from typing import Dict, List, Optional, Any, Callable
 import logging
 
-from application.services.misbuffet.algorithm.order import Order, OrderEvent
-from application.services.misbuffet.algorithm.symbol import Symbol
+from ..algorithm.order import Order, OrderEvent
+from ..algorithm.symbol import Symbol
 #from application.services.misbuffet.common.symbol import Symbol
 from domain.entities.finance.holding.holding import Holding
 

--- a/src/application/services/misbuffet/brokers/broker_factory.py
+++ b/src/application/services/misbuffet/brokers/broker_factory.py
@@ -9,7 +9,7 @@ import logging
 from typing import Dict, Any, Optional, Type
 from enum import Enum
 
-from src.application.services.misbuffet.launcher.interfaces import LauncherConfiguration
+from ..launcher.interfaces import LauncherConfiguration
 
 from .base_broker import BaseBroker
 from .ibkr.interactive_brokers_broker import InteractiveBrokersBroker

--- a/src/application/services/misbuffet/brokers/ibkr/contract_resolver.py
+++ b/src/application/services/misbuffet/brokers/ibkr/contract_resolver.py
@@ -1,4 +1,4 @@
-from application.services.misbuffet.brokers.ibkr import IBTWSClient
+from . import IBTWSClient
 from ibapi.contract import Contract
 import time
 import threading

--- a/src/application/services/misbuffet/brokers/ibkr/interactive_brokers_broker.py
+++ b/src/application/services/misbuffet/brokers/ibkr/interactive_brokers_broker.py
@@ -13,8 +13,8 @@ from typing import Dict, List, Optional, Any, Callable
 
 from ibapi.contract import Contract
 
-from application.services.misbuffet.brokers.ibkr.IBTWSClient import IBTWSClient
-from application.services.misbuffet.brokers.ibkr.contract_resolver import ContractResolver
+from .IBTWSClient import IBTWSClient
+from .contract_resolver import ContractResolver
 
 from ..base_broker import BaseBroker, BrokerStatus, BrokerConnectionState
 from ...common import Symbol, Order, OrderEvent

--- a/src/application/services/misbuffet/common/time_utils.py
+++ b/src/application/services/misbuffet/common/time_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime, time, timedelta
 from typing import Dict, Tuple
-from src.application.services.misbuffet.common.enums import Resolution
+from .enums import Resolution
 
 
 class Time:

--- a/test_circular_imports.py
+++ b/test_circular_imports.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Test script to verify circular import fixes in the misbuffet service.
+"""
+
+import sys
+import traceback
+
+def test_import(module_path, class_or_function_name=None):
+    """Test importing a module or specific class/function."""
+    try:
+        if class_or_function_name:
+            print(f"Testing: from {module_path} import {class_or_function_name}")
+            module = __import__(module_path, fromlist=[class_or_function_name])
+            imported_item = getattr(module, class_or_function_name)
+            print(f"✓ SUCCESS: {class_or_function_name} imported successfully")
+            return True
+        else:
+            print(f"Testing: import {module_path}")
+            __import__(module_path)
+            print(f"✓ SUCCESS: {module_path} imported successfully")
+            return True
+    except ImportError as e:
+        print(f"✗ IMPORT ERROR: {e}")
+        print(f"  Traceback: {traceback.format_exc()}")
+        return False
+    except Exception as e:
+        print(f"✗ UNEXPECTED ERROR: {e}")
+        print(f"  Traceback: {traceback.format_exc()}")
+        return False
+
+def main():
+    print("=" * 60)
+    print("Testing Circular Import Fixes for Misbuffet Service")
+    print("=" * 60)
+    
+    test_results = []
+    
+    # Test 1: Import Time from time_utils
+    print("\n1. Testing Time import from time_utils:")
+    result1 = test_import("src.application.services.misbuffet.common.time_utils", "Time")
+    test_results.append(("Time from time_utils", result1))
+    
+    # Test 2: Import the main misbuffet module  
+    print("\n2. Testing main misbuffet module import:")
+    result2 = test_import("src.application.services.misbuffet")
+    test_results.append(("Main misbuffet module", result2))
+    
+    # Test 3: Test broker-related imports
+    print("\n3. Testing broker-related imports:")
+    
+    # Test base broker
+    print("\n3a. Testing base broker import:")
+    result3a = test_import("src.application.services.misbuffet.brokers.base_broker")
+    test_results.append(("Base broker", result3a))
+    
+    # Test broker factory
+    print("\n3b. Testing broker factory import:")
+    result3b = test_import("src.application.services.misbuffet.brokers.broker_factory")
+    test_results.append(("Broker factory", result3b))
+    
+    # Test IBKR broker
+    print("\n3c. Testing IBKR broker import:")
+    result3c = test_import("src.application.services.misbuffet.brokers.ibkr.interactive_brokers_broker")
+    test_results.append(("IBKR broker", result3c))
+    
+    # Test 4: Additional key modules
+    print("\n4. Testing additional key modules:")
+    
+    # Test common modules
+    print("\n4a. Testing common data types:")
+    result4a = test_import("src.application.services.misbuffet.common.data_types")
+    test_results.append(("Common data types", result4a))
+    
+    # Test enums
+    print("\n4b. Testing enums:")
+    result4b = test_import("src.application.services.misbuffet.common.enums")
+    test_results.append(("Common enums", result4b))
+    
+    # Test securities
+    print("\n4c. Testing securities:")
+    result4c = test_import("src.application.services.misbuffet.common.securities")
+    test_results.append(("Common securities", result4c))
+    
+    # Test algorithm base
+    print("\n4d. Testing algorithm base:")
+    result4d = test_import("src.application.services.misbuffet.algorithm.base")
+    test_results.append(("Algorithm base", result4d))
+    
+    # Test engine
+    print("\n4e. Testing engine:")
+    result4e = test_import("src.application.services.misbuffet.engine.base_engine")
+    test_results.append(("Base engine", result4e))
+    
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY OF IMPORT TESTS")
+    print("=" * 60)
+    
+    passed = 0
+    failed = 0
+    
+    for test_name, result in test_results:
+        status = "✓ PASS" if result else "✗ FAIL"
+        print(f"{status}: {test_name}")
+        if result:
+            passed += 1
+        else:
+            failed += 1
+    
+    print(f"\nTotal: {len(test_results)} tests")
+    print(f"Passed: {passed}")
+    print(f"Failed: {failed}")
+    
+    if failed == 0:
+        print("\n🎉 All imports working correctly! Circular import issues resolved.")
+        return 0
+    else:
+        print(f"\n⚠️  {failed} imports still have issues that need to be fixed.")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Fix Time circular import in time_utils.py by changing absolute to relative import
- Convert broker module absolute imports to relative imports throughout codebase
- Resolves ImportError for Time class and related circular dependencies

## Key Changes
- **time_utils.py**: `from src.application.services.misbuffet.common.enums` → `from .enums`
- **base_broker.py**: Fix algorithm imports to relative paths
- **broker_factory.py**: Fix launcher interface import to relative path  
- **contract_resolver.py**: Fix IBTWSClient import to relative path
- **interactive_brokers_broker.py**: Fix all IBKR module imports to relative paths

## Test plan
- [x] Identify circular import root cause
- [x] Fix Time class import issue
- [x] Convert absolute to relative imports in broker modules
- [] Verify imports work in production environment

🤖 Generated with [Claude Code](https://claude.ai/code)