### PR TITLE
Add ports for domain entities following DDD pattern

### DIFF
--- a/src/domain/ports/__init__.py
+++ b/src/domain/ports/__init__.py
@@ -4,3 +4,39 @@ Domain Ports - Interfaces for repository and service contracts.
 This module contains abstract base classes (ports) that define contracts
 for infrastructure adapters following the Ports & Adapters pattern.
 """
+
+# Core entity ports
+from .continent_port import ContinentPort
+from .country_port import CountryPort
+from .industry_port import IndustryPort
+from .sector_port import SectorPort
+
+# Factor ports
+from .factor.factor_port import FactorPort
+from .factor.continent_factor_port import ContinentFactorPort
+from .factor.country_factor_port import CountryFactorPort
+
+# Finance ports
+from .finance.company_port import CompanyPort
+
+# Time series ports
+from .time_series.time_series_port import TimeSeriesPort
+
+__all__ = [
+    # Core entity ports
+    'ContinentPort',
+    'CountryPort', 
+    'IndustryPort',
+    'SectorPort',
+    
+    # Factor ports
+    'FactorPort',
+    'ContinentFactorPort',
+    'CountryFactorPort',
+    
+    # Finance ports
+    'CompanyPort',
+    
+    # Time series ports
+    'TimeSeriesPort',
+]

--- a/src/domain/ports/continent_port.py
+++ b/src/domain/ports/continent_port.py
@@ -1,0 +1,90 @@
+"""
+Continent Port - Repository interface for Continent entities.
+
+This port defines the contract for repositories that handle Continent
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.continent import Continent
+
+
+class ContinentPort(ABC):
+    """Port interface for Continent repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[Continent]:
+        """
+        Get continent by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            Continent entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Continent]:
+        """
+        Get continent by name.
+        
+        Args:
+            name: The continent name
+            
+        Returns:
+            Continent entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Continent]:
+        """
+        Get all continents.
+        
+        Returns:
+            List of Continent entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: Continent) -> Optional[Continent]:
+        """
+        Add/persist a continent entity.
+        
+        Args:
+            entity: The Continent entity to persist
+            
+        Returns:
+            Persisted Continent entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: Continent) -> Optional[Continent]:
+        """
+        Update a continent entity.
+        
+        Args:
+            entity: The Continent entity to update
+            
+        Returns:
+            Updated Continent entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a continent entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/country_port.py
+++ b/src/domain/ports/country_port.py
@@ -1,0 +1,103 @@
+"""
+Country Port - Repository interface for Country entities.
+
+This port defines the contract for repositories that handle Country
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.country import Country
+
+
+class CountryPort(ABC):
+    """Port interface for Country repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[Country]:
+        """
+        Get country by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            Country entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Country]:
+        """
+        Get country by name.
+        
+        Args:
+            name: The country name
+            
+        Returns:
+            Country entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_continent_id(self, continent_id: int) -> List[Country]:
+        """
+        Get countries by continent ID.
+        
+        Args:
+            continent_id: The continent ID
+            
+        Returns:
+            List of Country entities in the continent
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Country]:
+        """
+        Get all countries.
+        
+        Returns:
+            List of Country entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: Country) -> Optional[Country]:
+        """
+        Add/persist a country entity.
+        
+        Args:
+            entity: The Country entity to persist
+            
+        Returns:
+            Persisted Country entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: Country) -> Optional[Country]:
+        """
+        Update a country entity.
+        
+        Args:
+            entity: The Country entity to update
+            
+        Returns:
+            Updated Country entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a country entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/factor/__init__.py
+++ b/src/domain/ports/factor/__init__.py
@@ -1,0 +1,1 @@
+# Factor ports package

--- a/src/domain/ports/factor/continent_factor_port.py
+++ b/src/domain/ports/factor/continent_factor_port.py
@@ -1,0 +1,129 @@
+"""
+Continent Factor Port - Repository interface for ContinentFactor entities.
+
+This port defines the contract for repositories that handle ContinentFactor
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.factor.continent_factor import ContinentFactor
+
+
+class ContinentFactorPort(ABC):
+    """Port interface for ContinentFactor repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[ContinentFactor]:
+        """
+        Get continent factor by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            ContinentFactor entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[ContinentFactor]:
+        """
+        Get continent factor by name.
+        
+        Args:
+            name: The factor name
+            
+        Returns:
+            ContinentFactor entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_continent_code(self, continent_code: str) -> List[ContinentFactor]:
+        """
+        Get continent factors by continent code.
+        
+        Args:
+            continent_code: The continent code (e.g., 'NA', 'EU')
+            
+        Returns:
+            List of ContinentFactor entities for the continent
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_hemisphere(self, hemisphere: str) -> List[ContinentFactor]:
+        """
+        Get continent factors by hemisphere.
+        
+        Args:
+            hemisphere: The hemisphere ('northern', 'southern', 'both')
+            
+        Returns:
+            List of ContinentFactor entities in the hemisphere
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_group(self, group: str) -> List[ContinentFactor]:
+        """
+        Get continent factors by group.
+        
+        Args:
+            group: The factor group
+            
+        Returns:
+            List of ContinentFactor entities in the group
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[ContinentFactor]:
+        """
+        Get all continent factors.
+        
+        Returns:
+            List of ContinentFactor entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: ContinentFactor) -> Optional[ContinentFactor]:
+        """
+        Add/persist a continent factor entity.
+        
+        Args:
+            entity: The ContinentFactor entity to persist
+            
+        Returns:
+            Persisted ContinentFactor entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: ContinentFactor) -> Optional[ContinentFactor]:
+        """
+        Update a continent factor entity.
+        
+        Args:
+            entity: The ContinentFactor entity to update
+            
+        Returns:
+            Updated ContinentFactor entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a continent factor entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/factor/country_factor_port.py
+++ b/src/domain/ports/factor/country_factor_port.py
@@ -1,0 +1,142 @@
+"""
+Country Factor Port - Repository interface for CountryFactor entities.
+
+This port defines the contract for repositories that handle CountryFactor
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.factor.country_factor import CountryFactor
+
+
+class CountryFactorPort(ABC):
+    """Port interface for CountryFactor repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[CountryFactor]:
+        """
+        Get country factor by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            CountryFactor entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[CountryFactor]:
+        """
+        Get country factor by name.
+        
+        Args:
+            name: The factor name
+            
+        Returns:
+            CountryFactor entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_country_code(self, country_code: str) -> List[CountryFactor]:
+        """
+        Get country factors by country code.
+        
+        Args:
+            country_code: The country code (e.g., 'US', 'CA')
+            
+        Returns:
+            List of CountryFactor entities for the country
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_currency(self, currency: str) -> List[CountryFactor]:
+        """
+        Get country factors by currency.
+        
+        Args:
+            currency: The currency code (e.g., 'USD', 'EUR')
+            
+        Returns:
+            List of CountryFactor entities with the currency
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_development_status(self, is_developed: bool) -> List[CountryFactor]:
+        """
+        Get country factors by development status.
+        
+        Args:
+            is_developed: Whether the country is developed
+            
+        Returns:
+            List of CountryFactor entities with the development status
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_group(self, group: str) -> List[CountryFactor]:
+        """
+        Get country factors by group.
+        
+        Args:
+            group: The factor group
+            
+        Returns:
+            List of CountryFactor entities in the group
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[CountryFactor]:
+        """
+        Get all country factors.
+        
+        Returns:
+            List of CountryFactor entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: CountryFactor) -> Optional[CountryFactor]:
+        """
+        Add/persist a country factor entity.
+        
+        Args:
+            entity: The CountryFactor entity to persist
+            
+        Returns:
+            Persisted CountryFactor entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: CountryFactor) -> Optional[CountryFactor]:
+        """
+        Update a country factor entity.
+        
+        Args:
+            entity: The CountryFactor entity to update
+            
+        Returns:
+            Updated CountryFactor entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a country factor entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/factor/factor_port.py
+++ b/src/domain/ports/factor/factor_port.py
@@ -1,0 +1,116 @@
+"""
+Factor Port - Repository interface for Factor entities.
+
+This port defines the contract for repositories that handle Factor
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.factor.factor import Factor
+
+
+class FactorPort(ABC):
+    """Port interface for Factor repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[Factor]:
+        """
+        Get factor by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            Factor entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Factor]:
+        """
+        Get factor by name.
+        
+        Args:
+            name: The factor name
+            
+        Returns:
+            Factor entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_group(self, group: str) -> List[Factor]:
+        """
+        Get factors by group.
+        
+        Args:
+            group: The factor group
+            
+        Returns:
+            List of Factor entities in the group
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_subgroup(self, subgroup: str) -> List[Factor]:
+        """
+        Get factors by subgroup.
+        
+        Args:
+            subgroup: The factor subgroup
+            
+        Returns:
+            List of Factor entities in the subgroup
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Factor]:
+        """
+        Get all factors.
+        
+        Returns:
+            List of Factor entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: Factor) -> Optional[Factor]:
+        """
+        Add/persist a factor entity.
+        
+        Args:
+            entity: The Factor entity to persist
+            
+        Returns:
+            Persisted Factor entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: Factor) -> Optional[Factor]:
+        """
+        Update a factor entity.
+        
+        Args:
+            entity: The Factor entity to update
+            
+        Returns:
+            Updated Factor entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a factor entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/finance/__init__.py
+++ b/src/domain/ports/finance/__init__.py
@@ -1,0 +1,1 @@
+# Finance ports package

--- a/src/domain/ports/finance/company_port.py
+++ b/src/domain/ports/finance/company_port.py
@@ -1,0 +1,143 @@
+"""
+Company Port - Repository interface for Company entities.
+
+This port defines the contract for repositories that handle Company
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+from datetime import date
+
+from src.domain.entities.finance.company import Company
+
+
+class CompanyPort(ABC):
+    """Port interface for Company repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[Company]:
+        """
+        Get company by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            Company entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Company]:
+        """
+        Get company by name.
+        
+        Args:
+            name: The company name
+            
+        Returns:
+            Company entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_legal_name(self, legal_name: str) -> Optional[Company]:
+        """
+        Get company by legal name.
+        
+        Args:
+            legal_name: The company legal name
+            
+        Returns:
+            Company entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_country_id(self, country_id: int) -> List[Company]:
+        """
+        Get companies by country ID.
+        
+        Args:
+            country_id: The country ID
+            
+        Returns:
+            List of Company entities in the country
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_industry_id(self, industry_id: int) -> List[Company]:
+        """
+        Get companies by industry ID.
+        
+        Args:
+            industry_id: The industry ID
+            
+        Returns:
+            List of Company entities in the industry
+        """
+        pass
+    
+    @abstractmethod
+    def get_active_companies(self, as_of_date: Optional[date] = None) -> List[Company]:
+        """
+        Get active companies as of a specific date.
+        
+        Args:
+            as_of_date: Date to check activity (defaults to today)
+            
+        Returns:
+            List of active Company entities
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Company]:
+        """
+        Get all companies.
+        
+        Returns:
+            List of Company entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: Company) -> Optional[Company]:
+        """
+        Add/persist a company entity.
+        
+        Args:
+            entity: The Company entity to persist
+            
+        Returns:
+            Persisted Company entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: Company) -> Optional[Company]:
+        """
+        Update a company entity.
+        
+        Args:
+            entity: The Company entity to update
+            
+        Returns:
+            Updated Company entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a company entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/industry_port.py
+++ b/src/domain/ports/industry_port.py
@@ -1,0 +1,103 @@
+"""
+Industry Port - Repository interface for Industry entities.
+
+This port defines the contract for repositories that handle Industry
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.industry import Industry
+
+
+class IndustryPort(ABC):
+    """Port interface for Industry repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[Industry]:
+        """
+        Get industry by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            Industry entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Industry]:
+        """
+        Get industry by name.
+        
+        Args:
+            name: The industry name
+            
+        Returns:
+            Industry entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_sector_id(self, sector_id: int) -> List[Industry]:
+        """
+        Get industries by sector ID.
+        
+        Args:
+            sector_id: The sector ID
+            
+        Returns:
+            List of Industry entities in the sector
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Industry]:
+        """
+        Get all industries.
+        
+        Returns:
+            List of Industry entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: Industry) -> Optional[Industry]:
+        """
+        Add/persist an industry entity.
+        
+        Args:
+            entity: The Industry entity to persist
+            
+        Returns:
+            Persisted Industry entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: Industry) -> Optional[Industry]:
+        """
+        Update an industry entity.
+        
+        Args:
+            entity: The Industry entity to update
+            
+        Returns:
+            Updated Industry entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete an industry entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/sector_port.py
+++ b/src/domain/ports/sector_port.py
@@ -1,0 +1,90 @@
+"""
+Sector Port - Repository interface for Sector entities.
+
+This port defines the contract for repositories that handle Sector
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.sector import Sector
+
+
+class SectorPort(ABC):
+    """Port interface for Sector repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[Sector]:
+        """
+        Get sector by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            Sector entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Sector]:
+        """
+        Get sector by name.
+        
+        Args:
+            name: The sector name
+            
+        Returns:
+            Sector entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Sector]:
+        """
+        Get all sectors.
+        
+        Returns:
+            List of Sector entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: Sector) -> Optional[Sector]:
+        """
+        Add/persist a sector entity.
+        
+        Args:
+            entity: The Sector entity to persist
+            
+        Returns:
+            Persisted Sector entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: Sector) -> Optional[Sector]:
+        """
+        Update a sector entity.
+        
+        Args:
+            entity: The Sector entity to update
+            
+        Returns:
+            Updated Sector entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a sector entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass

--- a/src/domain/ports/time_series/__init__.py
+++ b/src/domain/ports/time_series/__init__.py
@@ -1,0 +1,1 @@
+# Time series ports package

--- a/src/domain/ports/time_series/time_series_port.py
+++ b/src/domain/ports/time_series/time_series_port.py
@@ -1,0 +1,132 @@
+"""
+Time Series Port - Repository interface for TimeSeries entities.
+
+This port defines the contract for repositories that handle TimeSeries
+entities, ensuring both local and external data source repositories implement the same interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+import pandas as pd
+
+from src.domain.entities.time_series.time_series import TimeSeries
+
+
+class TimeSeriesPort(ABC):
+    """Port interface for TimeSeries repositories"""
+    
+    @abstractmethod
+    def get_by_id(self, entity_id: int) -> Optional[TimeSeries]:
+        """
+        Get time series by ID.
+        
+        Args:
+            entity_id: The entity ID
+            
+        Returns:
+            TimeSeries entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[TimeSeries]:
+        """
+        Get time series by name.
+        
+        Args:
+            name: The time series name
+            
+        Returns:
+            TimeSeries entity or None if not found
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_date_range(self, start_date, end_date) -> List[TimeSeries]:
+        """
+        Get time series within date range.
+        
+        Args:
+            start_date: Start date
+            end_date: End date
+            
+        Returns:
+            List of TimeSeries entities within the date range
+        """
+        pass
+    
+    @abstractmethod
+    def get_by_columns(self, columns: List[str]) -> List[TimeSeries]:
+        """
+        Get time series containing specific columns.
+        
+        Args:
+            columns: List of column names to search for
+            
+        Returns:
+            List of TimeSeries entities containing the columns
+        """
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[TimeSeries]:
+        """
+        Get all time series.
+        
+        Returns:
+            List of TimeSeries entities
+        """
+        pass
+    
+    @abstractmethod
+    def add(self, entity: TimeSeries) -> Optional[TimeSeries]:
+        """
+        Add/persist a time series entity.
+        
+        Args:
+            entity: The TimeSeries entity to persist
+            
+        Returns:
+            Persisted TimeSeries entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def update(self, entity: TimeSeries) -> Optional[TimeSeries]:
+        """
+        Update a time series entity.
+        
+        Args:
+            entity: The TimeSeries entity to update
+            
+        Returns:
+            Updated TimeSeries entity or None if failed
+        """
+        pass
+    
+    @abstractmethod
+    def delete(self, entity_id: int) -> bool:
+        """
+        Delete a time series entity.
+        
+        Args:
+            entity_id: The entity ID to delete
+            
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        pass
+    
+    @abstractmethod
+    def save_dataframe(self, dataframe: pd.DataFrame, name: str) -> Optional[TimeSeries]:
+        """
+        Save a pandas DataFrame as a TimeSeries entity.
+        
+        Args:
+            dataframe: The DataFrame to save
+            name: Name for the time series
+            
+        Returns:
+            Created TimeSeries entity or None if failed
+        """
+        pass


### PR DESCRIPTION
Created port interfaces for core domain entities following DDD principles:

** Core entities:** continent, country, industry, sector
** Factor entities:** factor, continent_factor, country_factor
** Finance entities:** company
** Time series entities:** time_series

Each port follows the repository pattern with standard CRUD operations and entity-specific query methods. Maintains same directory structure as corresponding entities while providing clean abstractions for infrastructure implementations.

Fixes #270

Generated with [Claude Code](https://claude.ai/code)