### PR TITLE
Add comprehensive port interfaces for remaining domain entities

### DIFF
--- a/src/domain/ports/__init__.py
+++ b/src/domain/ports/__init__.py
@@ -18,9 +18,12 @@ from .factor.country_factor_port import CountryFactorPort
 
 # Finance ports
 from .finance.company_port import CompanyPort
+from .finance.exchange_port import ExchangePort
+from .finance.position_port import PositionPort
 
 # Time series ports
 from .time_series.time_series_port import TimeSeriesPort
+from .time_series.dask_time_series_port import DaskTimeSeriesPort
 
 __all__ = [
     # Core entity ports
@@ -36,7 +39,10 @@ __all__ = [
     
     # Finance ports
     'CompanyPort',
+    'ExchangePort',
+    'PositionPort',
     
     # Time series ports
     'TimeSeriesPort',
+    'DaskTimeSeriesPort',
 ]

--- a/src/domain/ports/finance/__init__.py
+++ b/src/domain/ports/finance/__init__.py
@@ -1,1 +1,11 @@
 # Finance ports package
+
+from .company_port import CompanyPort
+from .exchange_port import ExchangePort
+from .position_port import PositionPort
+
+__all__ = [
+    'CompanyPort',
+    'ExchangePort', 
+    'PositionPort',
+]

--- a/src/domain/ports/finance/exchange_port.py
+++ b/src/domain/ports/finance/exchange_port.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.exchange import Exchange
+
+
+class ExchangePort(ABC):
+    """Port interface for Exchange entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, exchange_id: int) -> Optional[Exchange]:
+        """Retrieve an exchange by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Exchange]:
+        """Retrieve all exchanges."""
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Exchange]:
+        """Retrieve an exchange by its name."""
+        pass
+    
+    @abstractmethod
+    def get_by_country_id(self, country_id: int) -> List[Exchange]:
+        """Retrieve exchanges by country ID."""
+        pass
+    
+    @abstractmethod
+    def get_active_exchanges(self) -> List[Exchange]:
+        """Retrieve all active exchanges (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, exchange: Exchange) -> Exchange:
+        """Add a new exchange."""
+        pass
+    
+    @abstractmethod
+    def update(self, exchange: Exchange) -> Exchange:
+        """Update an existing exchange."""
+        pass
+    
+    @abstractmethod
+    def delete(self, exchange_id: int) -> bool:
+        """Delete an exchange by its ID."""
+        pass

--- a/src/domain/ports/finance/financial_statements/__init__.py
+++ b/src/domain/ports/finance/financial_statements/__init__.py
@@ -1,0 +1,1 @@
+# Financial statements ports package

--- a/src/domain/ports/finance/financial_statements/financial_statement_port.py
+++ b/src/domain/ports/finance/financial_statements/financial_statement_port.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_statements.financial_statement import FinancialStatement
+
+
+class FinancialStatementPort(ABC):
+    """Port interface for FinancialStatement entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_company_id(self, company_id: int) -> List[FinancialStatement]:
+        """Retrieve financial statements by company ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[FinancialStatement]:
+        """Retrieve all financial statements."""
+        pass
+    
+    @abstractmethod
+    def get_by_period(self, period: str) -> List[FinancialStatement]:
+        """Retrieve financial statements by reporting period."""
+        pass
+    
+    @abstractmethod
+    def get_by_year(self, year: int) -> List[FinancialStatement]:
+        """Retrieve financial statements by year."""
+        pass
+    
+    @abstractmethod
+    def get_by_company_and_period(self, company_id: int, period: str, year: int) -> Optional[FinancialStatement]:
+        """Retrieve a specific financial statement by company, period, and year."""
+        pass
+    
+    @abstractmethod
+    def add(self, statement: FinancialStatement) -> FinancialStatement:
+        """Add a new financial statement."""
+        pass
+    
+    @abstractmethod
+    def update(self, statement: FinancialStatement) -> FinancialStatement:
+        """Update an existing financial statement."""
+        pass
+    
+    @abstractmethod
+    def delete(self, company_id: int, period: str, year: int) -> bool:
+        """Delete a financial statement by company, period, and year."""
+        pass

--- a/src/domain/ports/finance/holding/__init__.py
+++ b/src/domain/ports/finance/holding/__init__.py
@@ -1,0 +1,1 @@
+# Holding ports package

--- a/src/domain/ports/finance/holding/holding_port.py
+++ b/src/domain/ports/finance/holding/holding_port.py
@@ -1,0 +1,48 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.holding.holding import Holding
+from src.domain.entities.finance.financial_assets.financial_asset import FinancialAsset
+
+
+class HoldingPort(ABC):
+    """Port interface for Holding entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, holding_id: int) -> Optional[Holding]:
+        """Retrieve a holding by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Holding]:
+        """Retrieve all holdings."""
+        pass
+    
+    @abstractmethod
+    def get_by_asset(self, asset: FinancialAsset) -> List[Holding]:
+        """Retrieve holdings by asset."""
+        pass
+    
+    @abstractmethod
+    def get_by_container(self, container: object) -> List[Holding]:
+        """Retrieve holdings by container (portfolio, book, strategy, account)."""
+        pass
+    
+    @abstractmethod
+    def get_active_holdings(self) -> List[Holding]:
+        """Retrieve all active holdings (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, holding: Holding) -> Holding:
+        """Add a new holding."""
+        pass
+    
+    @abstractmethod
+    def update(self, holding: Holding) -> Holding:
+        """Update an existing holding."""
+        pass
+    
+    @abstractmethod
+    def delete(self, holding_id: int) -> bool:
+        """Delete a holding by its ID."""
+        pass

--- a/src/domain/ports/finance/holding/portfolio_company_share_holding_port.py
+++ b/src/domain/ports/finance/holding/portfolio_company_share_holding_port.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.holding.portfolio_company_share_holding import PortfolioCompanyShareHolding
+from src.domain.entities.finance.financial_assets.share.company_share.company_share import CompanyShare
+from src.domain.entities.finance.portfolio.portfolio_company_share import PortfolioCompanyShare
+
+
+class PortfolioCompanyShareHoldingPort(ABC):
+    """Port interface for PortfolioCompanyShareHolding entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, holding_id: int) -> Optional[PortfolioCompanyShareHolding]:
+        """Retrieve a portfolio company share holding by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[PortfolioCompanyShareHolding]:
+        """Retrieve all portfolio company share holdings."""
+        pass
+    
+    @abstractmethod
+    def get_by_company_share(self, company_share: CompanyShare) -> List[PortfolioCompanyShareHolding]:
+        """Retrieve holdings by company share."""
+        pass
+    
+    @abstractmethod
+    def get_by_portfolio(self, portfolio: PortfolioCompanyShare) -> List[PortfolioCompanyShareHolding]:
+        """Retrieve holdings by portfolio."""
+        pass
+    
+    @abstractmethod
+    def get_active_holdings(self) -> List[PortfolioCompanyShareHolding]:
+        """Retrieve all active holdings (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, holding: PortfolioCompanyShareHolding) -> PortfolioCompanyShareHolding:
+        """Add a new portfolio company share holding."""
+        pass
+    
+    @abstractmethod
+    def update(self, holding: PortfolioCompanyShareHolding) -> PortfolioCompanyShareHolding:
+        """Update an existing portfolio company share holding."""
+        pass
+    
+    @abstractmethod
+    def delete(self, holding_id: int) -> bool:
+        """Delete a portfolio company share holding by its ID."""
+        pass

--- a/src/domain/ports/finance/holding/portfolio_holding_port.py
+++ b/src/domain/ports/finance/holding/portfolio_holding_port.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.holding.portfolio_holding import PortfolioHolding
+from src.domain.entities.finance.portfolio.portfolio import Portfolio
+from src.domain.entities.finance.financial_assets.financial_asset import FinancialAsset
+
+
+class PortfolioHoldingPort(ABC):
+    """Port interface for PortfolioHolding entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, holding_id: int) -> Optional[PortfolioHolding]:
+        """Retrieve a portfolio holding by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[PortfolioHolding]:
+        """Retrieve all portfolio holdings."""
+        pass
+    
+    @abstractmethod
+    def get_by_portfolio(self, portfolio: Portfolio) -> List[PortfolioHolding]:
+        """Retrieve holdings by portfolio."""
+        pass
+    
+    @abstractmethod
+    def get_by_asset(self, asset: FinancialAsset) -> List[PortfolioHolding]:
+        """Retrieve holdings by asset."""
+        pass
+    
+    @abstractmethod
+    def get_active_holdings(self) -> List[PortfolioHolding]:
+        """Retrieve all active holdings (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, holding: PortfolioHolding) -> PortfolioHolding:
+        """Add a new portfolio holding."""
+        pass
+    
+    @abstractmethod
+    def update(self, holding: PortfolioHolding) -> PortfolioHolding:
+        """Update an existing portfolio holding."""
+        pass
+    
+    @abstractmethod
+    def delete(self, holding_id: int) -> bool:
+        """Delete a portfolio holding by its ID."""
+        pass

--- a/src/domain/ports/finance/portfolio/__init__.py
+++ b/src/domain/ports/finance/portfolio/__init__.py
@@ -1,0 +1,1 @@
+# Portfolio ports package

--- a/src/domain/ports/finance/portfolio/portfolio_company_share_port.py
+++ b/src/domain/ports/finance/portfolio/portfolio_company_share_port.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.portfolio.portfolio_company_share import PortfolioCompanyShare
+
+
+class PortfolioCompanySharePort(ABC):
+    """Port interface for PortfolioCompanyShare entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, portfolio_id: int) -> Optional[PortfolioCompanyShare]:
+        """Retrieve a company share portfolio by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[PortfolioCompanyShare]:
+        """Retrieve all company share portfolios."""
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[PortfolioCompanyShare]:
+        """Retrieve a company share portfolio by its name."""
+        pass
+    
+    @abstractmethod
+    def get_active_portfolios(self) -> List[PortfolioCompanyShare]:
+        """Retrieve all active company share portfolios (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, portfolio: PortfolioCompanyShare) -> PortfolioCompanyShare:
+        """Add a new company share portfolio."""
+        pass
+    
+    @abstractmethod
+    def update(self, portfolio: PortfolioCompanyShare) -> PortfolioCompanyShare:
+        """Update an existing company share portfolio."""
+        pass
+    
+    @abstractmethod
+    def delete(self, portfolio_id: int) -> bool:
+        """Delete a company share portfolio by its ID."""
+        pass

--- a/src/domain/ports/finance/portfolio/portfolio_port.py
+++ b/src/domain/ports/finance/portfolio/portfolio_port.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.portfolio.portfolio import Portfolio
+
+
+class PortfolioPort(ABC):
+    """Port interface for Portfolio entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, portfolio_id: int) -> Optional[Portfolio]:
+        """Retrieve a portfolio by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Portfolio]:
+        """Retrieve all portfolios."""
+        pass
+    
+    @abstractmethod
+    def get_by_name(self, name: str) -> Optional[Portfolio]:
+        """Retrieve a portfolio by its name."""
+        pass
+    
+    @abstractmethod
+    def get_active_portfolios(self) -> List[Portfolio]:
+        """Retrieve all active portfolios (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, portfolio: Portfolio) -> Portfolio:
+        """Add a new portfolio."""
+        pass
+    
+    @abstractmethod
+    def update(self, portfolio: Portfolio) -> Portfolio:
+        """Update an existing portfolio."""
+        pass
+    
+    @abstractmethod
+    def delete(self, portfolio_id: int) -> bool:
+        """Delete a portfolio by its ID."""
+        pass

--- a/src/domain/ports/finance/position_port.py
+++ b/src/domain/ports/finance/position_port.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.holding.position import Position, PositionType
+
+
+class PositionPort(ABC):
+    """Port interface for Position entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, position_id: int) -> Optional[Position]:
+        """Retrieve a position by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Position]:
+        """Retrieve all positions."""
+        pass
+    
+    @abstractmethod
+    def get_by_position_type(self, position_type: PositionType) -> List[Position]:
+        """Retrieve positions by position type (LONG/SHORT)."""
+        pass
+    
+    @abstractmethod
+    def get_by_quantity_range(self, min_quantity: int, max_quantity: int) -> List[Position]:
+        """Retrieve positions within a quantity range."""
+        pass
+    
+    @abstractmethod
+    def add(self, position: Position) -> Position:
+        """Add a new position."""
+        pass
+    
+    @abstractmethod
+    def update(self, position: Position) -> Position:
+        """Update an existing position."""
+        pass
+    
+    @abstractmethod
+    def delete(self, position_id: int) -> bool:
+        """Delete a position by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/__init__.py
+++ b/src/domain/ports/financial_assets/__init__.py
@@ -1,3 +1,29 @@
 """
 Financial Assets Ports - Repository interfaces for financial asset entities.
 """
+
+from .bond_port import BondPort
+from .cash_port import CashPort
+from .commodity_port import CommodityPort
+from .company_share_port import CompanySharePort
+from .crypto_port import CryptoPort
+from .currency_port import CurrencyPort
+from .equity_port import EquityPort
+from .financial_asset_port import FinancialAssetPort
+from .index_future_port import IndexFuturePort
+from .security_port import SecurityPort
+from .stock_port import StockPort
+
+__all__ = [
+    'BondPort',
+    'CashPort', 
+    'CommodityPort',
+    'CompanySharePort',
+    'CryptoPort',
+    'CurrencyPort',
+    'EquityPort',
+    'FinancialAssetPort',
+    'IndexFuturePort',
+    'SecurityPort',
+    'StockPort',
+]

--- a/src/domain/ports/financial_assets/cash_port.py
+++ b/src/domain/ports/financial_assets/cash_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.cash import Cash
+
+
+class CashPort(ABC):
+    """Port interface for Cash entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, cash_id: int) -> Optional[Cash]:
+        """Retrieve a cash entity by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Cash]:
+        """Retrieve all cash entities."""
+        pass
+    
+    @abstractmethod
+    def get_active_cash(self) -> List[Cash]:
+        """Retrieve all active cash entities (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, cash: Cash) -> Cash:
+        """Add a new cash entity."""
+        pass
+    
+    @abstractmethod
+    def update(self, cash: Cash) -> Cash:
+        """Update an existing cash entity."""
+        pass
+    
+    @abstractmethod
+    def delete(self, cash_id: int) -> bool:
+        """Delete a cash entity by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/commodity_port.py
+++ b/src/domain/ports/financial_assets/commodity_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.commodity import Commodity
+
+
+class CommodityPort(ABC):
+    """Port interface for Commodity entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, commodity_id: int) -> Optional[Commodity]:
+        """Retrieve a commodity entity by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Commodity]:
+        """Retrieve all commodity entities."""
+        pass
+    
+    @abstractmethod
+    def get_active_commodities(self) -> List[Commodity]:
+        """Retrieve all active commodity entities (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, commodity: Commodity) -> Commodity:
+        """Add a new commodity entity."""
+        pass
+    
+    @abstractmethod
+    def update(self, commodity: Commodity) -> Commodity:
+        """Update an existing commodity entity."""
+        pass
+    
+    @abstractmethod
+    def delete(self, commodity_id: int) -> bool:
+        """Delete a commodity entity by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/crypto_port.py
+++ b/src/domain/ports/financial_assets/crypto_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.crypto import Crypto
+
+
+class CryptoPort(ABC):
+    """Port interface for Crypto entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, crypto_id: int) -> Optional[Crypto]:
+        """Retrieve a crypto entity by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Crypto]:
+        """Retrieve all crypto entities."""
+        pass
+    
+    @abstractmethod
+    def get_active_cryptos(self) -> List[Crypto]:
+        """Retrieve all active crypto entities (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, crypto: Crypto) -> Crypto:
+        """Add a new crypto entity."""
+        pass
+    
+    @abstractmethod
+    def update(self, crypto: Crypto) -> Crypto:
+        """Update an existing crypto entity."""
+        pass
+    
+    @abstractmethod
+    def delete(self, crypto_id: int) -> bool:
+        """Delete a crypto entity by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/derivatives/__init__.py
+++ b/src/domain/ports/financial_assets/derivatives/__init__.py
@@ -1,0 +1,1 @@
+# Derivative ports package

--- a/src/domain/ports/financial_assets/derivatives/derivative_port.py
+++ b/src/domain/ports/financial_assets/derivatives/derivative_port.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.derivatives.derivative import Derivative
+from src.domain.entities.finance.financial_assets.financial_asset import FinancialAsset
+
+
+class DerivativePort(ABC):
+    """Port interface for Derivative entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, derivative_id: int) -> Optional[Derivative]:
+        """Retrieve a derivative by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Derivative]:
+        """Retrieve all derivatives."""
+        pass
+    
+    @abstractmethod
+    def get_by_underlying_asset(self, underlying_asset: FinancialAsset) -> List[Derivative]:
+        """Retrieve derivatives by their underlying asset."""
+        pass
+    
+    @abstractmethod
+    def get_active_derivatives(self) -> List[Derivative]:
+        """Retrieve all active derivatives (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, derivative: Derivative) -> Derivative:
+        """Add a new derivative."""
+        pass
+    
+    @abstractmethod
+    def update(self, derivative: Derivative) -> Derivative:
+        """Update an existing derivative."""
+        pass
+    
+    @abstractmethod
+    def delete(self, derivative_id: int) -> bool:
+        """Delete a derivative by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/equity_port.py
+++ b/src/domain/ports/financial_assets/equity_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.equity import Equity
+
+
+class EquityPort(ABC):
+    """Port interface for Equity entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, equity_id: int) -> Optional[Equity]:
+        """Retrieve an equity entity by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Equity]:
+        """Retrieve all equity entities."""
+        pass
+    
+    @abstractmethod
+    def get_active_equities(self) -> List[Equity]:
+        """Retrieve all active equity entities (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, equity: Equity) -> Equity:
+        """Add a new equity entity."""
+        pass
+    
+    @abstractmethod
+    def update(self, equity: Equity) -> Equity:
+        """Update an existing equity entity."""
+        pass
+    
+    @abstractmethod
+    def delete(self, equity_id: int) -> bool:
+        """Delete an equity entity by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/financial_asset_port.py
+++ b/src/domain/ports/financial_assets/financial_asset_port.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.financial_asset import FinancialAsset
+
+
+class FinancialAssetPort(ABC):
+    """Port interface for FinancialAsset entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, asset_id: int) -> Optional[FinancialAsset]:
+        """Retrieve a financial asset by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[FinancialAsset]:
+        """Retrieve all financial assets."""
+        pass
+    
+    @abstractmethod
+    def get_active_assets(self) -> List[FinancialAsset]:
+        """Retrieve all active financial assets (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def get_by_asset_type(self, asset_type: str) -> List[FinancialAsset]:
+        """Retrieve financial assets by their asset type."""
+        pass
+    
+    @abstractmethod
+    def add(self, asset: FinancialAsset) -> FinancialAsset:
+        """Add a new financial asset."""
+        pass
+    
+    @abstractmethod
+    def update(self, asset: FinancialAsset) -> FinancialAsset:
+        """Update an existing financial asset."""
+        pass
+    
+    @abstractmethod
+    def delete(self, asset_id: int) -> bool:
+        """Delete a financial asset by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/index/__init__.py
+++ b/src/domain/ports/financial_assets/index/__init__.py
@@ -1,0 +1,1 @@
+# Index ports package

--- a/src/domain/ports/financial_assets/index/index_port.py
+++ b/src/domain/ports/financial_assets/index/index_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.index.index import Index
+
+
+class IndexPort(ABC):
+    """Port interface for Index entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, index_id: int) -> Optional[Index]:
+        """Retrieve an index by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Index]:
+        """Retrieve all indexes."""
+        pass
+    
+    @abstractmethod
+    def get_active_indexes(self) -> List[Index]:
+        """Retrieve all active indexes (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, index: Index) -> Index:
+        """Add a new index."""
+        pass
+    
+    @abstractmethod
+    def update(self, index: Index) -> Index:
+        """Update an existing index."""
+        pass
+    
+    @abstractmethod
+    def delete(self, index_id: int) -> bool:
+        """Delete an index by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/index/vix_port.py
+++ b/src/domain/ports/financial_assets/index/vix_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.index.vix import Vix
+
+
+class VixPort(ABC):
+    """Port interface for Vix entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, vix_id: int) -> Optional[Vix]:
+        """Retrieve a VIX by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Vix]:
+        """Retrieve all VIX entities."""
+        pass
+    
+    @abstractmethod
+    def get_active_vix(self) -> List[Vix]:
+        """Retrieve all active VIX entities (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, vix: Vix) -> Vix:
+        """Add a new VIX entity."""
+        pass
+    
+    @abstractmethod
+    def update(self, vix: Vix) -> Vix:
+        """Update an existing VIX entity."""
+        pass
+    
+    @abstractmethod
+    def delete(self, vix_id: int) -> bool:
+        """Delete a VIX entity by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/security_port.py
+++ b/src/domain/ports/financial_assets/security_port.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.security import Security
+
+
+class SecurityPort(ABC):
+    """Port interface for Security entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, security_id: int) -> Optional[Security]:
+        """Retrieve a security by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Security]:
+        """Retrieve all securities."""
+        pass
+    
+    @abstractmethod
+    def get_active_securities(self) -> List[Security]:
+        """Retrieve all active securities (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def get_tradeable_securities(self) -> List[Security]:
+        """Retrieve all tradeable securities."""
+        pass
+    
+    @abstractmethod
+    def add(self, security: Security) -> Security:
+        """Add a new security."""
+        pass
+    
+    @abstractmethod
+    def update(self, security: Security) -> Security:
+        """Update an existing security."""
+        pass
+    
+    @abstractmethod
+    def delete(self, security_id: int) -> bool:
+        """Delete a security by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/share/__init__.py
+++ b/src/domain/ports/financial_assets/share/__init__.py
@@ -1,0 +1,1 @@
+# Share ports package

--- a/src/domain/ports/financial_assets/share/company_share/__init__.py
+++ b/src/domain/ports/financial_assets/share/company_share/__init__.py
@@ -1,0 +1,1 @@
+# Company share ports package

--- a/src/domain/ports/financial_assets/share/company_share/company_share_port.py
+++ b/src/domain/ports/financial_assets/share/company_share/company_share_port.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.share.company_share.company_share import CompanyShare
+
+
+class CompanySharePort(ABC):
+    """Port interface for CompanyShare entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, company_share_id: int) -> Optional[CompanyShare]:
+        """Retrieve a company share by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[CompanyShare]:
+        """Retrieve all company shares."""
+        pass
+    
+    @abstractmethod
+    def get_by_company_id(self, company_id: int) -> List[CompanyShare]:
+        """Retrieve company shares by company ID."""
+        pass
+    
+    @abstractmethod
+    def get_by_exchange_id(self, exchange_id: int) -> List[CompanyShare]:
+        """Retrieve company shares by exchange ID."""
+        pass
+    
+    @abstractmethod
+    def get_active_company_shares(self) -> List[CompanyShare]:
+        """Retrieve all active company shares (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, company_share: CompanyShare) -> CompanyShare:
+        """Add a new company share."""
+        pass
+    
+    @abstractmethod
+    def update(self, company_share: CompanyShare) -> CompanyShare:
+        """Update an existing company share."""
+        pass
+    
+    @abstractmethod
+    def delete(self, company_share_id: int) -> bool:
+        """Delete a company share by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/share/etf_share_port.py
+++ b/src/domain/ports/financial_assets/share/etf_share_port.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.share.etf_share import ETFShare
+
+
+class ETFSharePort(ABC):
+    """Port interface for ETFShare entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, etf_share_id: int) -> Optional[ETFShare]:
+        """Retrieve an ETF share by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[ETFShare]:
+        """Retrieve all ETF shares."""
+        pass
+    
+    @abstractmethod
+    def get_by_exchange_id(self, exchange_id: int) -> List[ETFShare]:
+        """Retrieve ETF shares by exchange ID."""
+        pass
+    
+    @abstractmethod
+    def get_active_etf_shares(self) -> List[ETFShare]:
+        """Retrieve all active ETF shares (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, etf_share: ETFShare) -> ETFShare:
+        """Add a new ETF share."""
+        pass
+    
+    @abstractmethod
+    def update(self, etf_share: ETFShare) -> ETFShare:
+        """Update an existing ETF share."""
+        pass
+    
+    @abstractmethod
+    def delete(self, etf_share_id: int) -> bool:
+        """Delete an ETF share by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/share/share_port.py
+++ b/src/domain/ports/financial_assets/share/share_port.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.share.share import Share
+
+
+class SharePort(ABC):
+    """Port interface for Share entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, share_id: int) -> Optional[Share]:
+        """Retrieve a share by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Share]:
+        """Retrieve all shares."""
+        pass
+    
+    @abstractmethod
+    def get_by_exchange_id(self, exchange_id: int) -> List[Share]:
+        """Retrieve shares by exchange ID."""
+        pass
+    
+    @abstractmethod
+    def get_active_shares(self) -> List[Share]:
+        """Retrieve all active shares (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, share: Share) -> Share:
+        """Add a new share."""
+        pass
+    
+    @abstractmethod
+    def update(self, share: Share) -> Share:
+        """Update an existing share."""
+        pass
+    
+    @abstractmethod
+    def delete(self, share_id: int) -> bool:
+        """Delete a share by its ID."""
+        pass

--- a/src/domain/ports/financial_assets/stock_port.py
+++ b/src/domain/ports/financial_assets/stock_port.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.finance.financial_assets.stock import Stock
+
+
+class StockPort(ABC):
+    """Port interface for Stock entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, stock_id: int) -> Optional[Stock]:
+        """Retrieve a stock by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[Stock]:
+        """Retrieve all stocks."""
+        pass
+    
+    @abstractmethod
+    def get_active_stocks(self) -> List[Stock]:
+        """Retrieve all active stocks (end_date is None or in the future)."""
+        pass
+    
+    @abstractmethod
+    def add(self, stock: Stock) -> Stock:
+        """Add a new stock."""
+        pass
+    
+    @abstractmethod
+    def update(self, stock: Stock) -> Stock:
+        """Update an existing stock."""
+        pass
+    
+    @abstractmethod
+    def delete(self, stock_id: int) -> bool:
+        """Delete a stock by its ID."""
+        pass

--- a/src/domain/ports/time_series/__init__.py
+++ b/src/domain/ports/time_series/__init__.py
@@ -1,1 +1,9 @@
 # Time series ports package
+
+from .time_series_port import TimeSeriesPort
+from .dask_time_series_port import DaskTimeSeriesPort
+
+__all__ = [
+    'TimeSeriesPort',
+    'DaskTimeSeriesPort',
+]

--- a/src/domain/ports/time_series/dask_time_series_port.py
+++ b/src/domain/ports/time_series/dask_time_series_port.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.time_series.dask_time_series import DaskTimeSeries
+import pandas as pd
+import dask.dataframe as dd
+
+
+class DaskTimeSeriesPort(ABC):
+    """Port interface for DaskTimeSeries entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, time_series_id: str) -> Optional[DaskTimeSeries]:
+        """Retrieve a Dask time series by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[DaskTimeSeries]:
+        """Retrieve all Dask time series."""
+        pass
+    
+    @abstractmethod
+    def get_by_columns(self, columns: List[str]) -> List[DaskTimeSeries]:
+        """Retrieve Dask time series containing specific columns."""
+        pass
+    
+    @abstractmethod
+    def get_by_date_range(self, start_date: pd.Timestamp, end_date: pd.Timestamp) -> List[DaskTimeSeries]:
+        """Retrieve Dask time series within a date range."""
+        pass
+    
+    @abstractmethod
+    def save_time_series(self, time_series_id: str, time_series: DaskTimeSeries) -> DaskTimeSeries:
+        """Save a Dask time series with the given ID."""
+        pass
+    
+    @abstractmethod
+    def update_time_series(self, time_series_id: str, time_series: DaskTimeSeries) -> DaskTimeSeries:
+        """Update an existing Dask time series."""
+        pass
+    
+    @abstractmethod
+    def delete(self, time_series_id: str) -> bool:
+        """Delete a Dask time series by its ID."""
+        pass
+    
+    @abstractmethod
+    def persist_to_storage(self, time_series: DaskTimeSeries, path: str) -> bool:
+        """Persist a Dask time series to storage (e.g., Parquet format)."""
+        pass

--- a/src/domain/ports/time_series/finance/__init__.py
+++ b/src/domain/ports/time_series/finance/__init__.py
@@ -1,0 +1,1 @@
+# Finance time series ports package

--- a/src/domain/ports/time_series/finance/financial_asset_time_series_port.py
+++ b/src/domain/ports/time_series/finance/financial_asset_time_series_port.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.time_series.finance.financial_asset_time_series import FinancialAssetTimeSeries
+from src.domain.entities.finance.financial_assets.financial_asset import FinancialAsset
+import pandas as pd
+
+
+class FinancialAssetTimeSeriesPort(ABC):
+    """Port interface for FinancialAssetTimeSeries entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, time_series_id: str) -> Optional[FinancialAssetTimeSeries]:
+        """Retrieve a financial asset time series by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[FinancialAssetTimeSeries]:
+        """Retrieve all financial asset time series."""
+        pass
+    
+    @abstractmethod
+    def get_by_asset(self, asset: FinancialAsset) -> List[FinancialAssetTimeSeries]:
+        """Retrieve time series by financial asset."""
+        pass
+    
+    @abstractmethod
+    def get_by_date_range(self, start_date: pd.Timestamp, end_date: pd.Timestamp) -> List[FinancialAssetTimeSeries]:
+        """Retrieve financial asset time series within a date range."""
+        pass
+    
+    @abstractmethod
+    def get_by_columns(self, columns: List[str]) -> List[FinancialAssetTimeSeries]:
+        """Retrieve financial asset time series containing specific columns (e.g., OHLCV)."""
+        pass
+    
+    @abstractmethod
+    def save_time_series(self, time_series_id: str, time_series: FinancialAssetTimeSeries) -> FinancialAssetTimeSeries:
+        """Save a financial asset time series with the given ID."""
+        pass
+    
+    @abstractmethod
+    def update_time_series(self, time_series_id: str, time_series: FinancialAssetTimeSeries) -> FinancialAssetTimeSeries:
+        """Update an existing financial asset time series."""
+        pass
+    
+    @abstractmethod
+    def delete(self, time_series_id: str) -> bool:
+        """Delete a financial asset time series by its ID."""
+        pass

--- a/src/domain/ports/time_series/finance/stock_time_series_port.py
+++ b/src/domain/ports/time_series/finance/stock_time_series_port.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from src.domain.entities.time_series.finance.stock_time_series import StockTimeSeries
+from src.domain.entities.finance.financial_assets.stock import Stock
+import pandas as pd
+
+
+class StockTimeSeriesPort(ABC):
+    """Port interface for StockTimeSeries entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, time_series_id: str) -> Optional[StockTimeSeries]:
+        """Retrieve a stock time series by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[StockTimeSeries]:
+        """Retrieve all stock time series."""
+        pass
+    
+    @abstractmethod
+    def get_by_stock(self, stock: Stock) -> List[StockTimeSeries]:
+        """Retrieve time series by stock."""
+        pass
+    
+    @abstractmethod
+    def get_by_sector(self, sector: str) -> List[StockTimeSeries]:
+        """Retrieve stock time series by sector."""
+        pass
+    
+    @abstractmethod
+    def get_by_country(self, country: str) -> List[StockTimeSeries]:
+        """Retrieve stock time series by country."""
+        pass
+    
+    @abstractmethod
+    def get_by_date_range(self, start_date: pd.Timestamp, end_date: pd.Timestamp) -> List[StockTimeSeries]:
+        """Retrieve stock time series within a date range."""
+        pass
+    
+    @abstractmethod
+    def save_time_series(self, time_series_id: str, time_series: StockTimeSeries) -> StockTimeSeries:
+        """Save a stock time series with the given ID."""
+        pass
+    
+    @abstractmethod
+    def update_time_series(self, time_series_id: str, time_series: StockTimeSeries) -> StockTimeSeries:
+        """Update an existing stock time series."""
+        pass
+    
+    @abstractmethod
+    def delete(self, time_series_id: str) -> bool:
+        """Delete a stock time series by its ID."""
+        pass

--- a/src/domain/ports/time_series/ml/__init__.py
+++ b/src/domain/ports/time_series/ml/__init__.py
@@ -1,0 +1,1 @@
+# ML time series ports package

--- a/src/domain/ports/time_series/ml/ml_time_series_port.py
+++ b/src/domain/ports/time_series/ml/ml_time_series_port.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple
+from src.domain.entities.time_series.ml.ml_time_series import MlTimeSeries
+import pandas as pd
+
+
+class MlTimeSeriesPort(ABC):
+    """Port interface for MlTimeSeries entity operations following repository pattern."""
+    
+    @abstractmethod
+    def get_by_id(self, time_series_id: str) -> Optional[MlTimeSeries]:
+        """Retrieve an ML time series by its ID."""
+        pass
+    
+    @abstractmethod
+    def get_all(self) -> List[MlTimeSeries]:
+        """Retrieve all ML time series."""
+        pass
+    
+    @abstractmethod
+    def get_by_target_column(self, y_column: str) -> List[MlTimeSeries]:
+        """Retrieve ML time series by target column."""
+        pass
+    
+    @abstractmethod
+    def get_by_features(self, x_columns: List[str]) -> List[MlTimeSeries]:
+        """Retrieve ML time series containing specific feature columns."""
+        pass
+    
+    @abstractmethod
+    def get_split_data(self, time_series_id: str) -> Optional[Tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]]:
+        """Retrieve train/test split data for an ML time series (train_x, train_y, test_x, test_y)."""
+        pass
+    
+    @abstractmethod
+    def save_time_series(self, time_series_id: str, time_series: MlTimeSeries) -> MlTimeSeries:
+        """Save an ML time series with the given ID."""
+        pass
+    
+    @abstractmethod
+    def update_time_series(self, time_series_id: str, time_series: MlTimeSeries) -> MlTimeSeries:
+        """Update an existing ML time series."""
+        pass
+    
+    @abstractmethod
+    def delete(self, time_series_id: str) -> bool:
+        """Delete an ML time series by its ID."""
+        pass
+    
+    @abstractmethod
+    def save_model_results(self, time_series_id: str, model_name: str, predictions: pd.Series, metrics: dict) -> bool:
+        """Save model predictions and metrics for an ML time series."""
+        pass


### PR DESCRIPTION
Created port interfaces following DDD repository pattern for:

**Financial Assets:**
- Basic assets: cash, commodity, crypto, equity, financial_asset, security, stock
- Derivatives: derivative base port
- Shares: share, etf_share, company_share 
- Indexes: index, vix

**Finance Core:**
- exchange, position
- Holdings: holding, portfolio_holding, portfolio_company_share_holding
- Portfolios: portfolio, portfolio_company_share
- Financial statements: financial_statement

**Time Series:**
- dask_time_series for distributed computing
- ML variants: ml_time_series
- Finance variants: financial_asset_time_series, stock_time_series

All ports implement standard CRUD operations with entity-specific query methods.
Updated __init__.py files for proper package structure and imports.

Fixes #270

🤖 Generated with [Claude Code](https://claude.ai/code)