### PR TITLE
feat: create infrastructure models mirroring domain entity structure

### DIFF
--- a/src/infrastructure/models/factor/__init__.py
+++ b/src/infrastructure/models/factor/__init__.py
@@ -1,0 +1,1 @@
+# Infrastructure models for factor domain entities

--- a/src/infrastructure/models/factor/factor.py
+++ b/src/infrastructure/models/factor/factor.py
@@ -1,0 +1,36 @@
+"""
+Infrastructure model for factor.
+SQLAlchemy model for domain factor entity.
+"""
+from sqlalchemy import Column, Integer, String, Text
+from src.infrastructure.models import ModelBase as Base
+
+
+class Factor(Base):
+    __tablename__ = 'factors'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), nullable=False)
+    group = Column(String(100), nullable=False)
+    subgroup = Column(String(100), nullable=True)
+    data_type = Column(String(100), nullable=True)
+    source = Column(String(255), nullable=True)
+    definition = Column(Text, nullable=True)
+    factor_type = Column(String(100), nullable=False)  # Discriminator for inheritance
+    
+    __mapper_args__ = {
+        'polymorphic_identity': 'factor',
+        'polymorphic_on': factor_type
+    }
+    
+    def __init__(self, name: str, group: str, subgroup: str = None, data_type: str = None,
+                 source: str = None, definition: str = None):
+        self.name = name
+        self.group = group
+        self.subgroup = subgroup
+        self.data_type = data_type
+        self.source = source
+        self.definition = definition
+    
+    def __repr__(self):
+        return f"<Factor(id={self.id}, name={self.name}, group={self.group})>"

--- a/src/infrastructure/models/factor/factor_value.py
+++ b/src/infrastructure/models/factor/factor_value.py
@@ -1,0 +1,30 @@
+"""
+Infrastructure model for factor value.
+SQLAlchemy model for domain factor value entity.
+"""
+from datetime import date
+from sqlalchemy import Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import relationship
+from src.infrastructure.models import ModelBase as Base
+
+
+class FactorValue(Base):
+    __tablename__ = 'factor_values'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    factor_id = Column(Integer, ForeignKey("factors.id"), nullable=False)
+    entity_id = Column(Integer, nullable=False)  # Generic entity reference
+    date = Column(Date, nullable=False)
+    value = Column(String(255), nullable=False)
+    
+    # Relationships
+    factor = relationship("Factor")
+    
+    def __init__(self, factor_id: int, entity_id: int, date: date, value: str):
+        self.factor_id = factor_id
+        self.entity_id = entity_id
+        self.date = date
+        self.value = value
+    
+    def __repr__(self):
+        return f"<FactorValue(id={self.id}, factor_id={self.factor_id}, entity_id={self.entity_id}, date={self.date})>"

--- a/src/infrastructure/models/finance/back_testing/__init__.py
+++ b/src/infrastructure/models/finance/back_testing/__init__.py
@@ -1,0 +1,1 @@
+# Infrastructure models for back testing domain entities

--- a/src/infrastructure/models/finance/back_testing/back_testing_data_types.py
+++ b/src/infrastructure/models/finance/back_testing/back_testing_data_types.py
@@ -1,0 +1,202 @@
+"""
+Infrastructure models for back testing data types.
+SQLAlchemy models for domain back testing data entities.
+"""
+from datetime import datetime, timedelta
+from decimal import Decimal
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey, Text, JSON, Interval
+from sqlalchemy.dialects.postgresql import DECIMAL
+from sqlalchemy.orm import relationship
+from src.infrastructure.models import ModelBase as Base
+
+
+class Bar(Base):
+    __tablename__ = 'bars'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    open = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    high = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    low = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    close = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    
+    def __init__(self, open_price: Decimal, high: Decimal, low: Decimal, close: Decimal):
+        self.open = open_price
+        self.high = high
+        self.low = low
+        self.close = close
+
+
+class TradeBar(Base):
+    __tablename__ = 'trade_bars'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    time = Column(DateTime, nullable=False)
+    data_type_id = Column(Integer, ForeignKey("data_types.id"), nullable=False)
+    open = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    high = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    low = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    close = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    volume = Column(Integer, nullable=False)
+    period = Column(Interval, nullable=True)
+    
+    # Relationships
+    symbol = relationship("Symbol")
+    data_type = relationship("DataTypeModel")
+    
+    def __init__(self, symbol_id: int, time: datetime, data_type_id: int, open_price: Decimal, 
+                 high: Decimal, low: Decimal, close: Decimal, volume: int, period: timedelta = None):
+        self.symbol_id = symbol_id
+        self.time = time
+        self.data_type_id = data_type_id
+        self.open = open_price
+        self.high = high
+        self.low = low
+        self.close = close
+        self.volume = volume
+        self.period = period or timedelta(minutes=1)
+
+
+class QuoteBar(Base):
+    __tablename__ = 'quote_bars'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    time = Column(DateTime, nullable=False)
+    data_type_id = Column(Integer, ForeignKey("data_types.id"), nullable=False)
+    bid_id = Column(Integer, ForeignKey("bars.id"), nullable=True)
+    ask_id = Column(Integer, ForeignKey("bars.id"), nullable=True)
+    last_bid_size = Column(Integer, default=0)
+    last_ask_size = Column(Integer, default=0)
+    period = Column(Interval, nullable=True)
+    
+    # Relationships
+    symbol = relationship("Symbol")
+    data_type = relationship("DataTypeModel")
+    bid = relationship("Bar", foreign_keys=[bid_id])
+    ask = relationship("Bar", foreign_keys=[ask_id])
+    
+    def __init__(self, symbol_id: int, time: datetime, data_type_id: int, bid_id: int = None, 
+                 ask_id: int = None, last_bid_size: int = 0, last_ask_size: int = 0, 
+                 period: timedelta = None):
+        self.symbol_id = symbol_id
+        self.time = time
+        self.data_type_id = data_type_id
+        self.bid_id = bid_id
+        self.ask_id = ask_id
+        self.last_bid_size = last_bid_size
+        self.last_ask_size = last_ask_size
+        self.period = period or timedelta(minutes=1)
+
+
+class Tick(Base):
+    __tablename__ = 'ticks'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    time = Column(DateTime, nullable=False)
+    data_type_id = Column(Integer, ForeignKey("data_types.id"), nullable=False)
+    tick_type_id = Column(Integer, ForeignKey("tick_types.id"), nullable=False)
+    value = Column(DECIMAL(precision=18, scale=8), nullable=True)
+    quantity = Column(Integer, default=0)
+    exchange = Column(String(100), nullable=True)
+    sale_condition = Column(String(100), nullable=True)
+    suspicious = Column(Boolean, default=False)
+    bid_price = Column(DECIMAL(precision=18, scale=8), nullable=True)
+    ask_price = Column(DECIMAL(precision=18, scale=8), nullable=True)
+    bid_size = Column(Integer, default=0)
+    ask_size = Column(Integer, default=0)
+    
+    # Relationships
+    symbol = relationship("Symbol")
+    data_type = relationship("DataTypeModel")
+    tick_type = relationship("TickTypeModel")
+    
+    def __init__(self, symbol_id: int, time: datetime, data_type_id: int, tick_type_id: int,
+                 quantity: int = 0, exchange: str = "", sale_condition: str = "", 
+                 suspicious: bool = False, bid_price: Decimal = None, ask_price: Decimal = None,
+                 bid_size: int = 0, ask_size: int = 0, value: Decimal = None):
+        self.symbol_id = symbol_id
+        self.time = time
+        self.data_type_id = data_type_id
+        self.tick_type_id = tick_type_id
+        self.value = value
+        self.quantity = quantity
+        self.exchange = exchange
+        self.sale_condition = sale_condition
+        self.suspicious = suspicious
+        self.bid_price = bid_price
+        self.ask_price = ask_price
+        self.bid_size = bid_size
+        self.ask_size = ask_size
+
+
+class Slice(Base):
+    __tablename__ = 'slices'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    time = Column(DateTime, nullable=False)
+    data = Column(JSON, nullable=True)  # Serialized data dictionary
+    
+    def __init__(self, time: datetime, data: dict = None):
+        self.time = time
+        self.data = data or {}
+
+
+class SubscriptionDataConfig(Base):
+    __tablename__ = 'subscription_data_configs'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    data_type_id = Column(Integer, ForeignKey("data_types.id"), nullable=False)
+    resolution = Column(String(50), nullable=False)
+    time_zone = Column(String(100), nullable=False)
+    market = Column(String(100), nullable=False)
+    fill_forward = Column(Boolean, default=True)
+    extended_market_hours = Column(Boolean, default=False)
+    is_custom_data = Column(Boolean, default=False)
+    data_normalization_mode = Column(String(50), default="Adjusted")
+    
+    # Relationships
+    symbol = relationship("Symbol")
+    data_type = relationship("DataTypeModel")
+    
+    def __init__(self, symbol_id: int, data_type_id: int, resolution: str, time_zone: str,
+                 market: str, fill_forward: bool = True, extended_market_hours: bool = False,
+                 is_custom_data: bool = False, data_normalization_mode: str = "Adjusted"):
+        self.symbol_id = symbol_id
+        self.data_type_id = data_type_id
+        self.resolution = resolution
+        self.time_zone = time_zone
+        self.market = market
+        self.fill_forward = fill_forward
+        self.extended_market_hours = extended_market_hours
+        self.is_custom_data = is_custom_data
+        self.data_normalization_mode = data_normalization_mode
+
+
+class MarketDataPoint(Base):
+    __tablename__ = 'market_data_points'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    time = Column(DateTime, nullable=False)
+    data_type_id = Column(Integer, ForeignKey("data_types.id"), nullable=False)
+    price = Column(DECIMAL(precision=18, scale=8), nullable=False)
+    volume = Column(Integer, nullable=True)
+    bid = Column(DECIMAL(precision=18, scale=8), nullable=True)
+    ask = Column(DECIMAL(precision=18, scale=8), nullable=True)
+    
+    # Relationships
+    symbol = relationship("Symbol")
+    data_type = relationship("DataTypeModel")
+    
+    def __init__(self, symbol_id: int, time: datetime, data_type_id: int, price: Decimal,
+                 volume: int = None, bid: Decimal = None, ask: Decimal = None):
+        self.symbol_id = symbol_id
+        self.time = time
+        self.data_type_id = data_type_id
+        self.price = price
+        self.volume = volume
+        self.bid = bid
+        self.ask = ask

--- a/src/infrastructure/models/finance/back_testing/enums.py
+++ b/src/infrastructure/models/finance/back_testing/enums.py
@@ -1,0 +1,107 @@
+"""
+Infrastructure models for back testing enums.
+SQLAlchemy models for domain enums.
+"""
+from sqlalchemy import Column, Integer, String, Enum as SQLEnum
+from src.infrastructure.models import ModelBase as Base
+from src.domain.entities.finance.back_testing.enums import (
+    Resolution, SecurityType, Market, OrderType, OrderStatus, OrderDirection,
+    TickType, DataType, OptionRight, OptionStyle, DataNormalizationMode,
+    AlgorithmStatus, InsightType, AccountType, Language, ServerType, PacketType
+)
+
+
+class ResolutionModel(Base):
+    __tablename__ = 'resolutions'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(Resolution), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: Resolution):
+        self.value = value
+        self.name = value.value
+
+
+class SecurityTypeModel(Base):
+    __tablename__ = 'security_types'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(SecurityType), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: SecurityType):
+        self.value = value
+        self.name = value.value
+
+
+class MarketModel(Base):
+    __tablename__ = 'markets'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(Market), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: Market):
+        self.value = value
+        self.name = value.value
+
+
+class OrderTypeModel(Base):
+    __tablename__ = 'order_types'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(OrderType), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: OrderType):
+        self.value = value
+        self.name = value.value
+
+
+class OrderStatusModel(Base):
+    __tablename__ = 'order_statuses'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(OrderStatus), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: OrderStatus):
+        self.value = value
+        self.name = value.value
+
+
+class OrderDirectionModel(Base):
+    __tablename__ = 'order_directions'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(OrderDirection), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: OrderDirection):
+        self.value = value
+        self.name = value.value
+
+
+class TickTypeModel(Base):
+    __tablename__ = 'tick_types'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(TickType), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: TickType):
+        self.value = value
+        self.name = value.value
+
+
+class DataTypeModel(Base):
+    __tablename__ = 'data_types'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(SQLEnum(DataType), nullable=False, unique=True)
+    name = Column(String(50), nullable=False)
+    
+    def __init__(self, value: DataType):
+        self.value = value
+        self.name = value.value

--- a/src/infrastructure/models/finance/back_testing/financial_assets/__init__.py
+++ b/src/infrastructure/models/finance/back_testing/financial_assets/__init__.py
@@ -1,0 +1,1 @@
+# Infrastructure models for back testing financial assets

--- a/src/infrastructure/models/finance/back_testing/financial_assets/symbol.py
+++ b/src/infrastructure/models/finance/back_testing/financial_assets/symbol.py
@@ -1,0 +1,110 @@
+"""
+Infrastructure models for symbol system.
+SQLAlchemy models for domain symbol entities.
+"""
+from datetime import datetime
+from decimal import Decimal
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey, Text, JSON
+from sqlalchemy.dialects.postgresql import DECIMAL
+from sqlalchemy.orm import relationship
+from src.infrastructure.models import ModelBase as Base
+from src.domain.entities.finance.back_testing.enums import SecurityType, Market
+
+
+class Symbol(Base):
+    __tablename__ = 'symbols'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    value = Column(String(255), nullable=False)
+    symbol_id = Column(String(255), nullable=False, unique=True)
+    security_type_id = Column(Integer, ForeignKey("security_types.id"), nullable=False)
+    market_id = Column(Integer, ForeignKey("markets.id"), nullable=False)
+    
+    # Relationships
+    security_type = relationship("SecurityTypeModel")
+    market = relationship("MarketModel")
+    properties = relationship("SymbolProperties", back_populates="symbol", uselist=False)
+    mappings = relationship("SymbolMapping", foreign_keys="SymbolMapping.original_symbol_id", back_populates="original_symbol")
+    
+    def __init__(self, value: str, symbol_id: str, security_type_id: int, market_id: int):
+        self.value = value
+        self.symbol_id = symbol_id
+        self.security_type_id = security_type_id
+        self.market_id = market_id
+    
+    def __repr__(self):
+        return f"<Symbol(value={self.value}, symbol_id={self.symbol_id})>"
+
+
+class SymbolProperties(Base):
+    __tablename__ = 'symbol_properties'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    time_zone = Column(String(100), default="America/New_York")
+    exchange_hours = Column(JSON, nullable=True)
+    lot_size = Column(Integer, default=1)
+    tick_size = Column(DECIMAL(precision=18, scale=8), default=Decimal('0.01'))
+    minimum_price_variation = Column(DECIMAL(precision=18, scale=8), default=Decimal('0.01'))
+    contract_multiplier = Column(Integer, default=1)
+    minimum_order_size = Column(Integer, default=1)
+    maximum_order_size = Column(Integer, nullable=True)
+    price_scaling = Column(DECIMAL(precision=18, scale=8), default=Decimal('1'))
+    margin_requirement = Column(DECIMAL(precision=18, scale=8), default=Decimal('0.25'))
+    short_able = Column(Boolean, default=True)
+    
+    # Relationships
+    symbol = relationship("Symbol", back_populates="properties")
+    
+    def __init__(self, symbol_id: int, time_zone: str = "America/New_York", lot_size: int = 1,
+                 tick_size: Decimal = Decimal('0.01'), minimum_price_variation: Decimal = Decimal('0.01'),
+                 contract_multiplier: int = 1, minimum_order_size: int = 1, maximum_order_size: int = None,
+                 price_scaling: Decimal = Decimal('1'), margin_requirement: Decimal = Decimal('0.25'),
+                 short_able: bool = True, exchange_hours: dict = None):
+        self.symbol_id = symbol_id
+        self.time_zone = time_zone
+        self.exchange_hours = exchange_hours
+        self.lot_size = lot_size
+        self.tick_size = tick_size
+        self.minimum_price_variation = minimum_price_variation
+        self.contract_multiplier = contract_multiplier
+        self.minimum_order_size = minimum_order_size
+        self.maximum_order_size = maximum_order_size
+        self.price_scaling = price_scaling
+        self.margin_requirement = margin_requirement
+        self.short_able = short_able
+
+
+class SymbolMapping(Base):
+    __tablename__ = 'symbol_mappings'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    original_symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    mapped_symbol_id = Column(Integer, ForeignKey("symbols.id"), nullable=False)
+    data_provider = Column(String(255), nullable=False)
+    mapping_date = Column(DateTime, default=datetime.utcnow)
+    
+    # Relationships
+    original_symbol = relationship("Symbol", foreign_keys=[original_symbol_id])
+    mapped_symbol = relationship("Symbol", foreign_keys=[mapped_symbol_id])
+    
+    def __init__(self, original_symbol_id: int, mapped_symbol_id: int, data_provider: str, 
+                 mapping_date: datetime = None):
+        self.original_symbol_id = original_symbol_id
+        self.mapped_symbol_id = mapped_symbol_id
+        self.data_provider = data_provider
+        self.mapping_date = mapping_date or datetime.utcnow()
+
+
+class SymbolSecurityDatabase(Base):
+    __tablename__ = 'symbol_security_databases'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    created_date = Column(DateTime, default=datetime.utcnow)
+    
+    def __init__(self, name: str, description: str = None):
+        self.name = name
+        self.description = description
+        self.created_date = datetime.utcnow()

--- a/src/infrastructure/models/finance/financial_statements/__init__.py
+++ b/src/infrastructure/models/finance/financial_statements/__init__.py
@@ -1,0 +1,1 @@
+# Infrastructure models for financial statements domain entities

--- a/src/infrastructure/models/finance/financial_statements/balance_sheet.py
+++ b/src/infrastructure/models/finance/financial_statements/balance_sheet.py
@@ -1,0 +1,29 @@
+"""
+Infrastructure model for balance sheet.
+SQLAlchemy model for domain balance sheet entity.
+"""
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.dialects.postgresql import DECIMAL
+from src.infrastructure.models.finance.financial_statements.financial_statement import FinancialStatement
+
+
+class BalanceSheet(FinancialStatement):
+    __tablename__ = 'balance_sheets'
+    
+    id = Column(Integer, ForeignKey("financial_statements.id"), primary_key=True)
+    assets = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    liabilities = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    equity = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    
+    __mapper_args__ = {
+        'polymorphic_identity': 'balance_sheet',
+    }
+    
+    def __init__(self, company_id: int, period: str, year: int, assets: float, liabilities: float, equity: float):
+        super().__init__(company_id, period, year)
+        self.assets = assets
+        self.liabilities = liabilities
+        self.equity = equity
+    
+    def __repr__(self):
+        return f"<BalanceSheet(company_id={self.company_id}, period={self.period}, year={self.year}, assets={self.assets})>"

--- a/src/infrastructure/models/finance/financial_statements/cash_flow_statement.py
+++ b/src/infrastructure/models/finance/financial_statements/cash_flow_statement.py
@@ -1,0 +1,30 @@
+"""
+Infrastructure model for cash flow statement.
+SQLAlchemy model for domain cash flow statement entity.
+"""
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.dialects.postgresql import DECIMAL
+from src.infrastructure.models.finance.financial_statements.financial_statement import FinancialStatement
+
+
+class CashFlowStatement(FinancialStatement):
+    __tablename__ = 'cash_flow_statements'
+    
+    id = Column(Integer, ForeignKey("financial_statements.id"), primary_key=True)
+    operating_cash_flow = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    investing_cash_flow = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    financing_cash_flow = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    
+    __mapper_args__ = {
+        'polymorphic_identity': 'cash_flow_statement',
+    }
+    
+    def __init__(self, company_id: int, period: str, year: int, operating_cash_flow: float, 
+                 investing_cash_flow: float, financing_cash_flow: float):
+        super().__init__(company_id, period, year)
+        self.operating_cash_flow = operating_cash_flow
+        self.investing_cash_flow = investing_cash_flow
+        self.financing_cash_flow = financing_cash_flow
+    
+    def __repr__(self):
+        return f"<CashFlowStatement(company_id={self.company_id}, period={self.period}, year={self.year})>"

--- a/src/infrastructure/models/finance/financial_statements/financial_statement.py
+++ b/src/infrastructure/models/finance/financial_statements/financial_statement.py
@@ -1,0 +1,33 @@
+"""
+Infrastructure models for financial statements.
+SQLAlchemy models for domain financial statement entities.
+"""
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+from src.infrastructure.models import ModelBase as Base
+
+
+class FinancialStatement(Base):
+    __tablename__ = 'financial_statements'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    company_id = Column(Integer, ForeignKey("companies.id"), nullable=False)
+    period = Column(String(20), nullable=False)  # Q1, Q2, Q3, Q4, Annual
+    year = Column(Integer, nullable=False)
+    statement_type = Column(String(50), nullable=False)  # Discriminator
+    
+    # Relationships
+    company = relationship("Company")
+    
+    __mapper_args__ = {
+        'polymorphic_identity': 'financial_statement',
+        'polymorphic_on': statement_type
+    }
+    
+    def __init__(self, company_id: int, period: str, year: int):
+        self.company_id = company_id
+        self.period = period
+        self.year = year
+    
+    def __repr__(self):
+        return f"<FinancialStatement(company_id={self.company_id}, period={self.period}, year={self.year})>"

--- a/src/infrastructure/models/finance/financial_statements/income_statement.py
+++ b/src/infrastructure/models/finance/financial_statements/income_statement.py
@@ -1,0 +1,29 @@
+"""
+Infrastructure model for income statement.
+SQLAlchemy model for domain income statement entity.
+"""
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.dialects.postgresql import DECIMAL
+from src.infrastructure.models.finance.financial_statements.financial_statement import FinancialStatement
+
+
+class IncomeStatement(FinancialStatement):
+    __tablename__ = 'income_statements'
+    
+    id = Column(Integer, ForeignKey("financial_statements.id"), primary_key=True)
+    revenue = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    expenses = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    net_income = Column(DECIMAL(precision=20, scale=2), nullable=False)
+    
+    __mapper_args__ = {
+        'polymorphic_identity': 'income_statement',
+    }
+    
+    def __init__(self, company_id: int, period: str, year: int, revenue: float, expenses: float, net_income: float):
+        super().__init__(company_id, period, year)
+        self.revenue = revenue
+        self.expenses = expenses
+        self.net_income = net_income
+    
+    def __repr__(self):
+        return f"<IncomeStatement(company_id={self.company_id}, period={self.period}, year={self.year}, revenue={self.revenue})>"

--- a/src/infrastructure/models/finance/position.py
+++ b/src/infrastructure/models/finance/position.py
@@ -1,0 +1,22 @@
+"""
+Infrastructure model for position.
+SQLAlchemy model for domain position entity.
+"""
+from sqlalchemy import Column, Integer, String, Enum as SQLEnum
+from src.infrastructure.models import ModelBase as Base
+from src.domain.entities.finance.holding.position import PositionType
+
+
+class Position(Base):
+    __tablename__ = 'positions'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    quantity = Column(Integer, nullable=False)
+    position_type = Column(SQLEnum(PositionType), nullable=False)
+    
+    def __init__(self, quantity: int, position_type: PositionType):
+        self.quantity = quantity
+        self.position_type = position_type
+    
+    def __repr__(self):
+        return f"<Position(id={self.id}, quantity={self.quantity}, position_type={self.position_type})>"

--- a/src/infrastructure/models/time_series/__init__.py
+++ b/src/infrastructure/models/time_series/__init__.py
@@ -1,0 +1,1 @@
+# Infrastructure models for time series domain entities

--- a/src/infrastructure/models/time_series/finance/__init__.py
+++ b/src/infrastructure/models/time_series/finance/__init__.py
@@ -1,0 +1,1 @@
+# Infrastructure models for financial time series domain entities

--- a/src/infrastructure/models/time_series/finance/financial_asset_time_series.py
+++ b/src/infrastructure/models/time_series/finance/financial_asset_time_series.py
@@ -1,0 +1,39 @@
+"""
+Infrastructure model for financial asset time series.
+SQLAlchemy model for domain financial asset time series entity.
+"""
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+from src.infrastructure.models.time_series.time_series import TimeSeries
+
+
+class FinancialAssetTimeSeries(TimeSeries):
+    __tablename__ = 'financial_asset_time_series'
+    
+    id = Column(Integer, ForeignKey("time_series.id"), primary_key=True)
+    financial_asset_id = Column(Integer, ForeignKey("financial_assets.id"), nullable=True)
+    
+    # Relationships
+    financial_asset = relationship("FinancialAsset")
+    
+    __mapper_args__ = {
+        'polymorphic_identity': 'financial_asset_time_series',
+    }
+    
+    def __init__(self, name: str, financial_asset_id: int = None, description: str = None,
+                 data_json: dict = None, data_binary: bytes = None, rows_count: int = None, 
+                 columns_count: int = None, columns_info: dict = None):
+        super().__init__(
+            name=name, 
+            series_type='financial_asset_time_series', 
+            description=description,
+            data_json=data_json,
+            data_binary=data_binary,
+            rows_count=rows_count,
+            columns_count=columns_count,
+            columns_info=columns_info
+        )
+        self.financial_asset_id = financial_asset_id
+    
+    def __repr__(self):
+        return f"<FinancialAssetTimeSeries(id={self.id}, name={self.name}, asset_id={self.financial_asset_id})>"

--- a/src/infrastructure/models/time_series/finance/stock_time_series.py
+++ b/src/infrastructure/models/time_series/finance/stock_time_series.py
@@ -1,0 +1,39 @@
+"""
+Infrastructure model for stock time series.
+SQLAlchemy model for domain stock time series entity.
+"""
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+from src.infrastructure.models.time_series.finance.financial_asset_time_series import FinancialAssetTimeSeries
+
+
+class StockTimeSeries(FinancialAssetTimeSeries):
+    __tablename__ = 'stock_time_series'
+    
+    id = Column(Integer, ForeignKey("financial_asset_time_series.id"), primary_key=True)
+    stock_id = Column(Integer, ForeignKey("stocks.id"), nullable=True)
+    
+    # Relationships  
+    stock = relationship("Stock")
+    
+    __mapper_args__ = {
+        'polymorphic_identity': 'stock_time_series',
+    }
+    
+    def __init__(self, name: str, stock_id: int = None, financial_asset_id: int = None,
+                 description: str = None, data_json: dict = None, data_binary: bytes = None,
+                 rows_count: int = None, columns_count: int = None, columns_info: dict = None):
+        super().__init__(
+            name=name,
+            financial_asset_id=financial_asset_id,
+            description=description,
+            data_json=data_json,
+            data_binary=data_binary,
+            rows_count=rows_count,
+            columns_count=columns_count,
+            columns_info=columns_info
+        )
+        self.stock_id = stock_id
+    
+    def __repr__(self):
+        return f"<StockTimeSeries(id={self.id}, name={self.name}, stock_id={self.stock_id})>"

--- a/src/infrastructure/models/time_series/time_series.py
+++ b/src/infrastructure/models/time_series/time_series.py
@@ -1,0 +1,46 @@
+"""
+Infrastructure model for time series.
+SQLAlchemy model for domain time series entity.
+"""
+from sqlalchemy import Column, Integer, String, Text, JSON, DateTime
+from sqlalchemy.dialects.postgresql import BYTEA
+from src.infrastructure.models import ModelBase as Base
+from datetime import datetime
+
+
+class TimeSeries(Base):
+    __tablename__ = 'time_series'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    series_type = Column(String(100), nullable=False)  # financial, ml, dask, etc.
+    
+    # Store serialized DataFrame data
+    data_json = Column(JSON, nullable=True)  # For small series, store as JSON
+    data_binary = Column(BYTEA, nullable=True)  # For large series, store as pickle/compressed binary
+    
+    # Metadata
+    rows_count = Column(Integer, nullable=True)
+    columns_count = Column(Integer, nullable=True)
+    columns_info = Column(JSON, nullable=True)  # Store column names and types
+    
+    created_date = Column(DateTime, default=datetime.utcnow)
+    updated_date = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    
+    def __init__(self, name: str, series_type: str, description: str = None, data_json: dict = None,
+                 data_binary: bytes = None, rows_count: int = None, columns_count: int = None,
+                 columns_info: dict = None):
+        self.name = name
+        self.series_type = series_type
+        self.description = description
+        self.data_json = data_json
+        self.data_binary = data_binary
+        self.rows_count = rows_count
+        self.columns_count = columns_count
+        self.columns_info = columns_info
+        self.created_date = datetime.utcnow()
+        self.updated_date = datetime.utcnow()
+    
+    def __repr__(self):
+        return f"<TimeSeries(id={self.id}, name={self.name}, type={self.series_type}, rows={self.rows_count})>"


### PR DESCRIPTION
Added SQLAlchemy infrastructure models for major missing domain entity areas:

- finance/back_testing/: Complete back testing models with enums, data types, and symbol management
- finance/financial_statements/: Full financial statement models with polymorphic inheritance
- time_series/: Time series models with JSON/binary data storage for pandas DataFrames
- factor/: Base factor models with polymorphic structure for extensibility
- finance/position.py: Position model with LONG/SHORT position types

This implements the requested domain-infrastructure mapping following DDD principles.
SQLAlchemy models use proper relationships, foreign keys, and decimal precision for financial data.

Addresses issue #274: Create src/infrastructure/models mirroring domain/entities structure.

Generated with [Claude Code](https://claude.ai/code)