### PR TITLE
Complete EntityService with all IBKR repositories and enhance DataLoader usage

### DIFF
--- a/src/application/services/data/entities/entity_service.py
+++ b/src/application/services/data/entities/entity_service.py
@@ -25,6 +25,8 @@ from src.domain.entities.finance.financial_assets.index.index import Index
 
 from src.infrastructure.repositories.local_repo.factor.factor_repository import FactorRepository
 from src.infrastructure.repositories.local_repo.factor.factor_value_repository import FactorValueRepository
+from src.infrastructure.repositories.ibkr_repo.factor.ibkr_factor_repository import IBKRFactorRepository
+from src.infrastructure.repositories.ibkr_repo.factor.ibkr_factor_value_repository import IBKRFactorValueRepository
 from src.infrastructure.repositories.ibkr_repo.finance.financial_assets.bond_repository import IBKRBondRepository
 from src.infrastructure.repositories.ibkr_repo.finance.financial_assets.cash_repository import IBKRCashRepository
 from src.infrastructure.repositories.ibkr_repo.finance.financial_assets.commodity_repository import IBKRCommodityRepository
@@ -132,6 +134,14 @@ class EntityService:
 
         # Wrap local repositories with IBKR implementations
         self.ibkr_repositories = {
+            'factor': IBKRFactorRepository(
+                ibkr_client=self.ib_broker,
+                local_repo=self.local_repositories['factor']
+            ),
+            'factor_value': IBKRFactorValueRepository(
+                ibkr_client=self.ib_broker,
+                local_repo=self.local_repositories['factor_value']
+            ),
             'index_future': IBKRIndexFutureRepository(
                 ibkr_client=self.ib_broker,
                 local_repo=self.local_repositories['index_future']


### PR DESCRIPTION
Complete EntityService with all IBKR repositories and enhance DataLoader usage

- Add IBKRFactorRepository and IBKRFactorValueRepository to EntityService
- Update create_ibkr_repositories() to include factor and factor_value repositories
- Fix DataLoader import path for EntityService
- Enhance DataLoader to use EntityService for Index and IndexFuture entity creation
- Add demonstration methods for EntityService factor and factor value usage
- Ensure both local and IBKR repositories are properly initialized

Fixes #281

🤖 Generated with [Claude Code](https://claude.ai/code)