### PR TITLE
Standardize SQLAlchemy relationship references to use full module paths

### DIFF
--- a/src/infrastructure/models/factor/factor_value.py
+++ b/src/infrastructure/models/factor/factor_value.py
@@ -18,7 +18,7 @@ class FactorValueModel(Base):
     value = Column(String(255), nullable=False)
     
     # Relationships
-    factor = relationship("Factor")
+    factor = relationship("src.infrastructure.models.factor.factor.FactorModel")
     
     def __init__(self, factor_id: int, entity_id: int, date: date, value: str):
         self.factor_id = factor_id

--- a/src/infrastructure/models/finance/company.py
+++ b/src/infrastructure/models/finance/company.py
@@ -15,9 +15,9 @@ class CompanyModel(Base):
     end_date = Column(Date, nullable=True)
 
     # Relationships
-    countries = relationship("Country", back_populates="companies")
-    industries = relationship("Industry", back_populates="companies")
-    company_shares = relationship("CompanyShare", back_populates="companies")
+    countries = relationship("src.infrastructure.models.country.CountryModel", back_populates="companies")
+    industries = relationship("src.infrastructure.models.industry.IndustryModel", back_populates="companies")
+    company_shares = relationship("src.infrastructure.models.finance.financial_assets.company_share.CompanyShareModel", back_populates="companies")
     
     def __init__(self, name, legal_name, country_id, industry_id, start_date, end_date=None):
         self.name = name

--- a/src/infrastructure/models/finance/exchange.py
+++ b/src/infrastructure/models/finance/exchange.py
@@ -14,10 +14,10 @@ class ExchangeModel(Base):
     end_date = Column(Date, nullable=True)
 
     # Relationships
-    countries = relationship("Country", back_populates="exchanges")
-    shares = relationship("Share", back_populates="exchanges")
-    company_shares = relationship("CompanyShare", back_populates="exchanges")
-    etf_shares = relationship("ETFShare", back_populates="exchanges")
+    countries = relationship("src.infrastructure.models.country.CountryModel", back_populates="exchanges")
+    shares = relationship("src.infrastructure.models.finance.financial_assets.share.ShareModel", back_populates="exchanges")
+    company_shares = relationship("src.infrastructure.models.finance.financial_assets.company_share.CompanyShareModel", back_populates="exchanges")
+    etf_shares = relationship("src.infrastructure.models.finance.financial_assets.etf_share.ETFShareModel", back_populates="exchanges")
 
     def __init__(self, name, legal_name, country_id, start_date, end_date=None):
         self.name = name

--- a/src/infrastructure/models/finance/financial_assets/company_share.py
+++ b/src/infrastructure/models/finance/financial_assets/company_share.py
@@ -27,8 +27,8 @@ class CompanyShareModel(Base):
     is_tradeable = Column(Boolean, default=True)
 
     # Relationships
-    companies = relationship("Company", back_populates="company_shares")
-    exchanges = relationship("Exchange", back_populates="company_shares") 
+    companies = relationship("src.infrastructure.models.finance.company.CompanyModel", back_populates="company_shares")
+    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_shares") 
 
     def __repr__(self):
         return f"<CompanyShare(id={self.id}, ticker={self.ticker}, company_id={self.company_id})>"

--- a/src/infrastructure/models/finance/financial_assets/currency.py
+++ b/src/infrastructure/models/finance/financial_assets/currency.py
@@ -36,7 +36,7 @@ class CurrencyModel(Base):
     is_tradeable = Column(Boolean, default=True)
     
     # Relationships
-    country = relationship("Country", back_populates="currencies")
+    country = relationship("src.infrastructure.models.country.CountryModel", back_populates="currencies")
 
     def __repr__(self):
         return f"<Currency(id={self.id}, iso_code={self.iso_code}, name={self.name}, country_id={self.country_id})>"
@@ -56,7 +56,7 @@ class CurrencyRate(Base):
     target_currency = Column(String(3), default="USD", nullable=False)  # Usually USD
     
     # Relationships
-    currency = relationship("Currency", backref="historical_rates")
+    currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel", backref="historical_rates")
 
     def __repr__(self):
         return f"<CurrencyRate(id={self.id}, currency_id={self.currency_id}, rate={self.rate}, timestamp={self.timestamp}, target={self.target_currency})>"

--- a/src/infrastructure/models/finance/financial_assets/etf_share.py
+++ b/src/infrastructure/models/finance/financial_assets/etf_share.py
@@ -45,7 +45,7 @@ class ETFShareModel(Base):
     industry = Column(String(100), nullable=True)
 
     # Relationships
-    exchanges = relationship("Exchange", back_populates="etf_shares")
+    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="etf_shares")
 
     def __repr__(self):
         return f"<ETFShare(id={self.id}, ticker={self.ticker}, fund_name={self.fund_name})>"

--- a/src/infrastructure/models/finance/financial_assets/financial_asset.py
+++ b/src/infrastructure/models/finance/financial_assets/financial_asset.py
@@ -73,7 +73,9 @@ class FinancialAssetModel(Base):
     last_price_update = Column(DateTime, nullable=True)
 
     # Relationships
-    instruments = relationship("Instrument", back_populates="asset", cascade="all, delete-orphan")
+    instruments = relationship("src.infrastructure.models.finance.instrument.InstrumentModel", back_populates="asset", cascade="all, delete-orphan")
+    holdings = relationship("src.infrastructure.models.finance.holding.holding.HoldingModel", back_populates="asset")
+    portfolio_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_holding.PortfolioHoldingsModel", back_populates="financial_asset")
 
     def __repr__(self):
         return f"<FinancialAsset(id={self.id}, type={self.asset_type}, ticker={self.ticker}, price={self.current_price})>"

--- a/src/infrastructure/models/finance/financial_assets/security.py
+++ b/src/infrastructure/models/finance/financial_assets/security.py
@@ -83,8 +83,8 @@ class SecurityModel(Base):
     last_market_update = Column(DateTime, nullable=True)
 
     # Relationships
-    portfolios = relationship("Portfolio", back_populates="securities")
-    market_data_history = relationship("MarketDataModel", 
+    portfolios = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="securities")
+    market_data_history = relationship("src.infrastructure.models.finance.market_data.MarketDataModel", 
                                      primaryjoin="and_(Security.ticker==MarketDataModel.symbol_ticker, "
                                                "Security.exchange==MarketDataModel.symbol_exchange)",
                                      foreign_keys="[MarketDataModel.symbol_ticker, MarketDataModel.symbol_exchange]",

--- a/src/infrastructure/models/finance/financial_assets/share.py
+++ b/src/infrastructure/models/finance/financial_assets/share.py
@@ -21,7 +21,7 @@ class ShareModel(Base):
     start_date = Column(Date, nullable=False)
     end_date = Column(Date, nullable=True)
     
-    exchanges = relationship("Exchange", back_populates="shares") 
+    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="shares") 
 
     def __repr__(self):
         return f"<Share(id={self.id}, ticker={self.ticker})>"

--- a/src/infrastructure/models/finance/holding/holding.py
+++ b/src/infrastructure/models/finance/holding/holding.py
@@ -24,6 +24,6 @@ class HoldingModel(Base):
     end_date = Column(DateTime, nullable=True)
 
     # Relationships
-    asset = relationship("FinancialAsset", back_populates="holdings")
+    asset = relationship("src.infrastructure.models.finance.financial_assets.financial_asset.FinancialAssetModel", back_populates="holdings")
 
 

--- a/src/infrastructure/models/finance/holding/portfolio_holding.py
+++ b/src/infrastructure/models/finance/holding/portfolio_holding.py
@@ -16,7 +16,7 @@ class PortfolioHoldingsModel(Base):
     portfolio_id = Column(Integer, ForeignKey('portfolios.id'), nullable=False)
 
     # Relationships
-    portfolios = relationship("Portfolio", back_populates="portfolio_holdings")
-    financial_financial_assetsasset = relationship("FinancialAsset", back_populates="portfolio_holdings")
+    portfolios = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="portfolio_holdings")
+    financial_asset = relationship("src.infrastructure.models.finance.financial_assets.financial_asset.FinancialAssetModel", back_populates="portfolio_holdings")
 
 

--- a/src/infrastructure/models/finance/instrument.py
+++ b/src/infrastructure/models/finance/instrument.py
@@ -29,7 +29,7 @@ class InstrumentModel(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
     
     # Relationships
-    asset = relationship("FinancialAsset", back_populates="instruments")
+    asset = relationship("src.infrastructure.models.finance.financial_assets.financial_asset.FinancialAssetModel", back_populates="instruments")
     
     def __init__(self, asset_id: int, source: str, date: datetime):
         """

--- a/src/infrastructure/models/finance/portfolio/portfolio.py
+++ b/src/infrastructure/models/finance/portfolio/portfolio.py
@@ -28,10 +28,10 @@ class PortfolioModel(Base):
    
 
     # Relationships
-    positions = relationship("Position", back_populates="portfolios")
-    portfolio_holdings = relationship("PortfolioHoldings", back_populates="portfolios", cascade="all, delete-orphan")
-    portfolio_statistics = relationship("PortfolioStatistics", back_populates="portfolios", cascade="all, delete-orphan")
-    securities = relationship("Security", back_populates="portfolios", cascade="all, delete-orphan")
+    positions = relationship("src.infrastructure.models.finance.position.PositionModel", back_populates="portfolios")
+    portfolio_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_holding.PortfolioHoldingsModel", back_populates="portfolios", cascade="all, delete-orphan")
+    portfolio_statistics = relationship("src.infrastructure.models.finance.portfolio.portfolio_statistics.PortfolioStatisticsModel", back_populates="portfolios", cascade="all, delete-orphan")
+    securities = relationship("src.infrastructure.models.finance.financial_assets.security.SecurityModel", back_populates="portfolios", cascade="all, delete-orphan")
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Standardizes all SQLAlchemy relationship references to use consistent full module path format

## Changes
- Updated 13 core models with full module path relationships
- Pattern: `relationship("src.infrastructure.models.{module_path}.{ModelClass}")`
- Improves string relationship resolution reliability
- Eliminates class name ambiguity in large codebase
- Follows production-grade SQLAlchemy best practices

## Models Updated
- ExchangeModel, CompanyModel, ShareModel, CompanyShareModel
- ETFShareModel, CurrencyModel, PortfolioModel, FinancialAssetModel
- SecurityModel, InstrumentModel, HoldingModel, FactorValueModel
- PortfolioHoldingsModel

## Benefits
- Consistent with your existing reference pattern
- Better IDE support and debugging
- Eliminates "expression failed to locate name" errors
- Production-ready relationship resolution

Resolves #296

🤖 Generated with [Claude Code](https://claude.ai/code)