### PR TITLE
Fix SQLAlchemy relationship back_populates mismatches

### DIFF
--- a/src/infrastructure/models/country.py
+++ b/src/infrastructure/models/country.py
@@ -14,11 +14,11 @@ class CountryModel(Base):
     continent_id = Column(Integer, ForeignKey("continents.id"), nullable=True)
 
     # Relationships
-    continents = relationship("src.infrastructure.models.continent.ContinentModel", back_populates="countries")
+    continent = relationship("src.infrastructure.models.continent.ContinentModel", back_populates="countries")
 
-    companies = relationship("src.infrastructure.models.finance.company.CompanyModel", back_populates="countries")
-    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="countries")
-    currencies = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel", back_populates="countries")
+    companies = relationship("src.infrastructure.models.finance.company.CompanyModel", back_populates="country")
+    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="country")
+    currencies = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel", back_populates="country")
     def __init__(self, name, iso_code, region=None):
         self.name = name
         self.iso_code = iso_code

--- a/src/infrastructure/models/factor/factor_value.py
+++ b/src/infrastructure/models/factor/factor_value.py
@@ -18,7 +18,7 @@ class FactorValueModel(Base):
     value = Column(String(255), nullable=False)
     
     # Relationships
-    factors = relationship("src.infrastructure.models.factor.factor.FactorModel",back_populates="factor_values")
+    factor = relationship("src.infrastructure.models.factor.factor.FactorModel",back_populates="factor_values")
     
     
     def __init__(self, factor_id: int, entity_id: int, date: Date, value: str):

--- a/src/infrastructure/models/finance/company.py
+++ b/src/infrastructure/models/finance/company.py
@@ -15,9 +15,9 @@ class CompanyModel(Base):
     end_date = Column(Date, nullable=True)
 
     # Relationships
-    countries = relationship("src.infrastructure.models.country.CountryModel", back_populates="companies")
-    industries = relationship("src.infrastructure.models.industry.IndustryModel", back_populates="companies")
-    company_shares = relationship("src.infrastructure.models.finance.financial_assets.company_share.CompanyShareModel", back_populates="companies")
+    country = relationship("src.infrastructure.models.country.CountryModel", back_populates="companies")
+    industry = relationship("src.infrastructure.models.industry.IndustryModel", back_populates="companies")
+    company_shares = relationship("src.infrastructure.models.finance.financial_assets.company_share.CompanyShareModel", back_populates="company")
     
     def __init__(self, name, legal_name, country_id, industry_id, start_date, end_date=None):
         self.name = name

--- a/src/infrastructure/models/finance/exchange.py
+++ b/src/infrastructure/models/finance/exchange.py
@@ -14,7 +14,7 @@ class ExchangeModel(Base):
     end_date = Column(Date, nullable=True)
 
     # Relationships
-    countries = relationship("src.infrastructure.models.country.CountryModel", back_populates="exchanges")
+    country = relationship("src.infrastructure.models.country.CountryModel", back_populates="exchanges")
     shares = relationship("src.infrastructure.models.finance.financial_assets.share.ShareModel", back_populates="exchanges")
     company_shares = relationship("src.infrastructure.models.finance.financial_assets.company_share.CompanyShareModel", back_populates="exchanges")
     etf_shares = relationship("src.infrastructure.models.finance.financial_assets.etf_share.ETFShareModel", back_populates="exchanges")

--- a/src/infrastructure/models/finance/financial_assets/company_share.py
+++ b/src/infrastructure/models/finance/financial_assets/company_share.py
@@ -27,8 +27,8 @@ class CompanyShareModel(Base):
     is_tradeable = Column(Boolean, default=True)
 
     # Relationships
-    companies = relationship("src.infrastructure.models.finance.company.CompanyModel", back_populates="company_shares")
-    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_shares") 
+    company = relationship("src.infrastructure.models.finance.company.CompanyModel", back_populates="company_shares")
+    exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_shares") 
 
     def __repr__(self):
         return f"<CompanyShare(id={self.id}, ticker={self.ticker}, company_id={self.company_id})>"

--- a/src/infrastructure/models/finance/financial_assets/currency.py
+++ b/src/infrastructure/models/finance/financial_assets/currency.py
@@ -36,7 +36,7 @@ class CurrencyModel(Base):
     is_tradeable = Column(Boolean, default=True)
     
     # Relationships
-    countries = relationship("src.infrastructure.models.country.CountryModel", back_populates="currencies")
+    country = relationship("src.infrastructure.models.country.CountryModel", back_populates="currencies")
     
     def __repr__(self):
         return f"<Currency(id={self.id}, iso_code={self.iso_code}, name={self.name}, country_id={self.country_id})>"

--- a/src/infrastructure/models/finance/financial_assets/etf_share.py
+++ b/src/infrastructure/models/finance/financial_assets/etf_share.py
@@ -45,7 +45,7 @@ class ETFShareModel(Base):
     industry = Column(String(100), nullable=True)
 
     # Relationships
-    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="etf_shares")
+    exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="etf_shares")
 
     def __repr__(self):
         return f"<ETFShare(id={self.id}, ticker={self.ticker}, fund_name={self.fund_name})>"

--- a/src/infrastructure/models/finance/financial_assets/security.py
+++ b/src/infrastructure/models/finance/financial_assets/security.py
@@ -83,7 +83,7 @@ class SecurityModel(Base):
     last_market_update = Column(DateTime, nullable=True)
 
     # Relationships
-    portfolios = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="securities")
+    portfolio = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="securities")
     
 
     def __repr__(self):

--- a/src/infrastructure/models/finance/financial_assets/share.py
+++ b/src/infrastructure/models/finance/financial_assets/share.py
@@ -21,7 +21,7 @@ class ShareModel(Base):
     start_date = Column(Date, nullable=False)
     end_date = Column(Date, nullable=True)
     
-    exchanges = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="shares") 
+    exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="shares") 
 
     def __repr__(self):
         return f"<Share(id={self.id}, ticker={self.ticker})>"

--- a/src/infrastructure/models/finance/holding/portfolio_holding.py
+++ b/src/infrastructure/models/finance/holding/portfolio_holding.py
@@ -16,7 +16,7 @@ class PortfolioHoldingsModel(Base):
     portfolio_id = Column(Integer, ForeignKey('portfolios.id'), nullable=False)
 
     # Relationships
-    portfolios = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="portfolio_holdings")
+    portfolio = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="portfolio_holdings")
     financial_asset = relationship("src.infrastructure.models.finance.financial_assets.financial_asset.FinancialAssetModel", back_populates="portfolio_holdings")
 
 

--- a/src/infrastructure/models/finance/holding/security_holding.py
+++ b/src/infrastructure/models/finance/holding/security_holding.py
@@ -33,7 +33,7 @@ class SecurityHoldingModel(Base):
     updated_at = Column(DateTime, nullable=True)
     
     # Relationships
-    portfolios = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="security_holdings")
+    portfolio = relationship("src.infrastructure.models.finance.portfolio.portfolio.PortfolioModel", back_populates="security_holdings")
     
     def __repr__(self):
         return (

--- a/src/infrastructure/models/finance/portfolio/portfolio.py
+++ b/src/infrastructure/models/finance/portfolio/portfolio.py
@@ -26,10 +26,10 @@ class PortfolioModel(Base):
     #     back_populates="portfolio",
     #     cascade="all, delete-orphan"
     # )
-    portfolio_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_holding.PortfolioHoldingsModel", back_populates="portfolios")
-    security_holdings = relationship("src.infrastructure.models.finance.holding.security_holding.SecurityHoldingModel", back_populates="portfolios")
-    #portfolio_statistics = relationship("src.infrastructure.models.finance.portfolio.portfolio_statistics.PortfolioStatisticsModel", back_populates="portfolios", cascade="all, delete-orphan")
-    securities = relationship("src.infrastructure.models.finance.financial_assets.security.SecurityModel", back_populates="portfolios")
+    portfolio_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_holding.PortfolioHoldingsModel", back_populates="portfolio")
+    security_holdings = relationship("src.infrastructure.models.finance.holding.security_holding.SecurityHoldingModel", back_populates="portfolio")
+    #portfolio_statistics = relationship("src.infrastructure.models.finance.portfolio.portfolio_statistics.PortfolioStatisticsModel", back_populates="portfolio", cascade="all, delete-orphan")
+    securities = relationship("src.infrastructure.models.finance.financial_assets.security.SecurityModel", back_populates="portfolio")
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Fixes SQLAlchemy mapper initialization errors by correcting relationship naming conventions

## Problem
`reverse_property 'portfolios' on relationship PortfolioModel.portfolio_holdings references relationship PortfolioHoldingsModel.portfolios, which does not reference mapper Mapper[PortfolioModel(portfolios)]`

## Root Cause
Many-to-one relationships were incorrectly using plural names instead of singular for the child side of relationships.

## Solution
- Fixed 13 models with incorrect relationship cardinality naming
- Applied consistent naming convention:
  - One-to-Many (Parent): plural names (`countries`, `companies`)
  - Many-to-One (Child): singular names (`country`, `company`)

## Models Updated
- PortfolioHoldingsModel: `portfolios` → `portfolio`
- SecurityHoldingModel: `portfolios` → `portfolio`
- SecurityModel: `portfolios` → `portfolio`
- FactorValueModel: `factors` → `factor`
- ExchangeModel: `countries` → `country`
- ShareModel: `exchanges` → `exchange`
- CompanyShareModel: `companies` → `company`, `exchanges` → `exchange`
- ETFShareModel: `exchanges` → `exchange`
- CompanyModel: `countries` → `country`, `industries` → `industry`
- CurrencyModel: `countries` → `country`
- CountryModel: `continents` → `continent`
- PortfolioModel: Updated back_populates to match corrected child relationships

## Result
SQLAlchemy mapper initialization should now succeed without "expression failed to locate name" errors.

Resolves #296

🤖 Generated with [Claude Code](https://claude.ai/code)