### PR TITLE
Establish foreign keys for financial asset models

### DIFF
--- a/src/infrastructure/models/finance/financial_assets/bond.py
+++ b/src/infrastructure/models/finance/financial_assets/bond.py
@@ -18,11 +18,16 @@ class BondModel(FinancialAssetModel):
     # Primary key is also foreign key to parent
     id = Column(Integer, ForeignKey("financial_assets.id"), primary_key=True)
     
+    # Currency relationship
+    currency_id = Column(Integer, ForeignKey('currencies.id'), nullable=True, index=True)
     
 
     __mapper_args__ = {
         "polymorphic_identity": "bond",
     }
+
+    # Relationships
+    currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel", foreign_keys=[currency_id])
 
     def __repr__(self):
         return f"<Bond(id={self.id}, isin={self.isin}, issuer={self.issuer})>"

--- a/src/infrastructure/models/finance/financial_assets/cash.py
+++ b/src/infrastructure/models/finance/financial_assets/cash.py
@@ -17,8 +17,14 @@ class CashModel(FinancialAssetModel):
 
     id = Column(Integer, ForeignKey("financial_assets.id"), primary_key=True)
     
+    # Currency relationship (required for cash)
+    currency_id = Column(Integer, ForeignKey('currencies.id'), nullable=False, index=True)
+    
     __mapper_args__ = {
-    "polymorphic_identity": "cash",
-}
+        "polymorphic_identity": "cash",
+    }
+
+    # Relationships
+    currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel", foreign_keys=[currency_id])
     def __repr__(self):
         return f"<Cash(id={self.id})>"

--- a/src/infrastructure/models/finance/financial_assets/commodity.py
+++ b/src/infrastructure/models/finance/financial_assets/commodity.py
@@ -16,11 +16,16 @@ class CommodityModel(FinancialAssetModel):
     
     # Primary key is also foreign key to parent
     id = Column(Integer, ForeignKey("financial_assets.id"), primary_key=True)
-   
+    
+    # Currency relationship
+    currency_id = Column(Integer, ForeignKey('currencies.id'), nullable=True, index=True)
 
     __mapper_args__ = {
         "polymorphic_identity": "commodity",
     }
+
+    # Relationships
+    currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel", foreign_keys=[currency_id])
 
     def __repr__(self):
         return f"<Commodity(id={self.id}, ticker={self.ticker}, name={self.name}, price={self.current_price})>"

--- a/src/infrastructure/models/finance/financial_assets/crypto.py
+++ b/src/infrastructure/models/finance/financial_assets/crypto.py
@@ -4,6 +4,7 @@ ORM model for Crypto - separate from src.domain entity to avoid metaclass confli
 
 from sqlalchemy import Column, Integer, String, Date, Numeric, Boolean, DateTime, BigInteger, Text
 from sqlalchemy import ForeignKey
+from sqlalchemy.orm import relationship
 from src.infrastructure.models.finance.financial_assets.financial_asset import FinancialAssetModel
 
 class CryptoModel(FinancialAssetModel):
@@ -16,8 +17,14 @@ class CryptoModel(FinancialAssetModel):
     # Primary key is also foreign key to parent
     id = Column(Integer, ForeignKey("financial_assets.id"), primary_key=True)
     
+    # Currency relationship (base currency for pricing)
+    currency_id = Column(Integer, ForeignKey('currencies.id'), nullable=True, index=True)
+    
     __mapper_args__ = {
-    "polymorphic_identity": "crypto",
-}
+        "polymorphic_identity": "crypto",
+    }
+
+    # Relationships
+    currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel", foreign_keys=[currency_id])
     def __repr__(self):
         return f"<Crypto(id={self.id}, symbol={self.symbol}, name={self.name})>"

--- a/src/infrastructure/models/finance/financial_assets/currency.py
+++ b/src/infrastructure/models/finance/financial_assets/currency.py
@@ -33,6 +33,10 @@ class CurrencyModel(FinancialAssetModel):
     country = relationship("src.infrastructure.models.country.CountryModel", back_populates="currency")
     indices = relationship("src.infrastructure.models.finance.financial_assets.index.IndexModel", foreign_keys="IndexModel.currency_id",back_populates="currency")
     derivatives = relationship("src.infrastructure.models.finance.financial_assets.derivative.derivatives.DerivativeModel",foreign_keys="DerivativeModel.currency_id", back_populates="currency")
+    bonds = relationship("src.infrastructure.models.finance.financial_assets.bond.BondModel", foreign_keys="BondModel.currency_id")
+    commodities = relationship("src.infrastructure.models.finance.financial_assets.commodity.CommodityModel", foreign_keys="CommodityModel.currency_id")
+    cryptos = relationship("src.infrastructure.models.finance.financial_assets.crypto.CryptoModel", foreign_keys="CryptoModel.currency_id")
+    cash_assets = relationship("src.infrastructure.models.finance.financial_assets.cash.CashModel", foreign_keys="CashModel.currency_id")
     def __repr__(self):
         return f"<Currency(id={self.id}, name={self.name}, country_id={self.country_id})>"
 


### PR DESCRIPTION
Establishes foreign keys consistently across all financial asset models following the same pattern as CurrencyModel, DerivativeModel, and FinancialAssetModel.

## Changes
- Added currency_id foreign key to BondModel, CommodityModel, CryptoModel
- Added currency_id foreign key to CashModel (required for cash assets)
- Added bidirectional relationships to CurrencyModel for all new foreign keys
- Maintains consistency across all financial asset models for currency relationships

Fixes #306

Generated with [Claude Code](https://claude.ai/code)