### PR TITLE
feat: add factory parameter support to repository constructors

### DIFF
--- a/src/infrastructure/repositories/ibkr_repo/factor/ibkr_factor_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/factor/ibkr_factor_repository.py
@@ -20,15 +20,17 @@ class IBKRFactorRepository(BaseIBKRFactorRepository, FactorPort):
     Handles factor metadata acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: FactorPort):
+    def __init__(self, ibkr_client, local_repo: FactorPort, factory=None):
         """
         Initialize IBKR Factor Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client
-            local_factor_repo: Local repository implementing FactorPort for persistence
+            local_repo: Local repository implementing FactorPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         super().__init__(ibkr_client, local_repo)
+        self.factory = factory
 
     # FactorPort interface implementation (delegate to local repository)
 

--- a/src/infrastructure/repositories/ibkr_repo/finance/company_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/company_repository.py
@@ -21,16 +21,18 @@ class IBKRCompanyRepository(BaseIBKRRepository, CompanyPort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: CompanyPort):
+    def __init__(self, ibkr_client, local_repo: CompanyPort, factory=None):
         """
         Initialize IBKR Company Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing CompanyPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
 
     @property
     def entity_class(self):

--- a/src/infrastructure/repositories/ibkr_repo/finance/exchange_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/exchange_repository.py
@@ -21,16 +21,18 @@ class IBKRExchangeRepository(BaseIBKRRepository, ExchangePort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: ExchangePort):
+    def __init__(self, ibkr_client, local_repo: ExchangePort, factory=None):
         """
         Initialize IBKR Exchange Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing ExchangePort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
 
     @property
     def entity_class(self):

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/bond_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/bond_repository.py
@@ -23,16 +23,18 @@ class IBKRBondRepository(IBKRFinancialAssetRepository, BondPort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: BondPort):
+    def __init__(self, ibkr_client, local_repo: BondPort, factory=None):
         """
         Initialize IBKR Bond Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing BondPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
 
     @property
     def entity_class(self):

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/cash_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/cash_repository.py
@@ -23,16 +23,18 @@ class IBKRCashRepository(IBKRFinancialAssetRepository, CashPort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: CashPort):
+    def __init__(self, ibkr_client, local_repo: CashPort, factory=None):
         """
         Initialize IBKR Cash Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing CashPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
     @property
     def entity_class(self):
         """Return the domain entity class for Cash."""

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/commodity_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/commodity_repository.py
@@ -23,16 +23,18 @@ class IBKRCommodityRepository(IBKRFinancialAssetRepository, CommodityPort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: CommodityPort):
+    def __init__(self, ibkr_client, local_repo: CommodityPort, factory=None):
         """
         Initialize IBKR Commodity Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing CommodityPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
 
     @property
     def entity_class(self):

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/company_share_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/company_share_repository.py
@@ -32,6 +32,7 @@ class IBKRCompanyShareRepository(IBKRFinancialAssetRepository, CompanySharePort)
         self, 
         ibkr_client, 
         local_repo: CompanySharePort,
+        factory=None,
         factor_repo: Optional['IBKRCompanyShareFactorRepository'] = None
     ):
         """
@@ -40,10 +41,12 @@ class IBKRCompanyShareRepository(IBKRFinancialAssetRepository, CompanySharePort)
         Args:
             ibkr_client: Interactive Brokers API client
             local_repo: Local repository implementing CompanySharePort for persistence
+            factory: Repository factory for dependency injection (optional)
             factor_repo: IBKR factor repository for factor-related operations (optional)
         """
         super().__init__(ibkr_client)
         self.local_repo = local_repo
+        self.factory = factory
         self.factor_repo = factor_repo
 
     @property

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/currency_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/currency_repository.py
@@ -23,16 +23,18 @@ class IBKRCurrencyRepository(IBKRFinancialAssetRepository, CurrencyPort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: CurrencyPort):
+    def __init__(self, ibkr_client, local_repo: CurrencyPort, factory=None):
         """
         Initialize IBKR Currency Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing CurrencyPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
     @property
     def entity_class(self):
         """Return the domain entity class for Currency."""

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/equity_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/equity_repository.py
@@ -23,16 +23,18 @@ class IBKREquityRepository(IBKRFinancialAssetRepository, EquityPort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: EquityPort):
+    def __init__(self, ibkr_client, local_repo: EquityPort, factory=None):
         """
         Initialize IBKR Equity Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing EquityPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
     @property
     def entity_class(self):
         """Return the domain entity class for Equity."""

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/etf_share_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/etf_share_repository.py
@@ -23,16 +23,18 @@ class IBKRETFShareRepository(IBKRFinancialAssetRepository, ETFSharePort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: ETFSharePort):
+    def __init__(self, ibkr_client, local_repo: ETFSharePort, factory=None):
         """
         Initialize IBKR ETF Share Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing EtfSharePort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
     @property
     def entity_class(self):
         """Return the domain entity class for ETFShare."""

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/security_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/security_repository.py
@@ -22,16 +22,18 @@ class IBKRSecurityRepository(IBKRFinancialAssetRepository, SecurityPort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: SecurityPort):
+    def __init__(self, ibkr_client, local_repo: SecurityPort, factory=None):
         """
         Initialize IBKR Security Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing SecurityPort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
     @property
     def entity_class(self):
         """Return the domain entity class for Security."""

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/share_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/share_repository.py
@@ -23,16 +23,18 @@ class IBKRShareRepository(IBKRFinancialAssetRepository, SharePort):
     Handles data acquisition from Interactive Brokers API and delegates persistence to local repository.
     """
 
-    def __init__(self, ibkr_client, local_repo: SharePort):
+    def __init__(self, ibkr_client, local_repo: SharePort, factory=None):
         """
         Initialize IBKR Share Repository.
         
         Args:
             ibkr_client: Interactive Brokers API client (InteractiveBrokersBroker instance)
             local_repo: Local repository implementing SharePort for persistence
+            factory: Repository factory for dependency injection (optional)
         """
         self.ib_broker = ibkr_client  # Use ib_broker for consistency with reference implementation
         self.local_repo = local_repo
+        self.factory = factory
     @property
     def entity_class(self):
         """Return the domain entity class for Share."""

--- a/src/infrastructure/repositories/repository_factory.py
+++ b/src/infrastructure/repositories/repository_factory.py
@@ -78,7 +78,7 @@ class RepositoryFactory:
                 'base_factor': BaseFactorRepository(self.session),
                 'share_factor': ShareFactorRepository(self.session),
                 'index_future': IndexFutureRepository(self.session),
-                'company_share': CompanyShareRepository(self.session),
+                'company_share': CompanyShareRepository(self.session, factory=self),
                 'currency': CurrencyRepository(self.session),
                 'bond': BondRepository(self.session),
                 'index': IndexRepository(self.session),
@@ -116,7 +116,8 @@ class RepositoryFactory:
             self._ibkr_repositories = {
                 'factor': IBKRFactorRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['factor']
+                    local_repo=local_repos['factor'],
+                    factory=self
                 ),
                 'factor_value': IBKRFactorValueRepository(
                     ibkr_client=client,
@@ -128,15 +129,18 @@ class RepositoryFactory:
                 ),
                 'company_share': IBKRCompanyShareRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['company_share']
+                    local_repo=local_repos['company_share'],
+                    factory=self
                 ),
                 'currency': IBKRCurrencyRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['currency']
+                    local_repo=local_repos['currency'],
+                    factory=self
                 ),
                 'bond': IBKRBondRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['bond']
+                    local_repo=local_repos['bond'],
+                    factory=self
                 ),
                 'index': IBKRIndexRepository(
                     ibkr_client=client,
@@ -149,27 +153,33 @@ class RepositoryFactory:
                 ),
                 'commodity': IBKRCommodityRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['commodity']
+                    local_repo=local_repos['commodity'],
+                    factory=self
                 ),
                 'cash': IBKRCashRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['cash']
+                    local_repo=local_repos['cash'],
+                    factory=self
                 ),
                 'equity': IBKREquityRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['equity']
+                    local_repo=local_repos['equity'],
+                    factory=self
                 ),
                 'etf_share': IBKRETFShareRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['etf_share']
+                    local_repo=local_repos['etf_share'],
+                    factory=self
                 ),
                 'share': IBKRShareRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['share']
+                    local_repo=local_repos['share'],
+                    factory=self
                 ),
                 'security': IBKRSecurityRepository(
                     ibkr_client=client,
-                    local_repo=local_repos['security']
+                    local_repo=local_repos['security'],
+                    factory=self
                 )
             }
         return self._ibkr_repositories


### PR DESCRIPTION
## Summary
- Updated 12 IBKR repository constructors to accept factory=None parameter
- Modified CompanyShareRepository to accept factory and use it for dependency resolution 
- Updated RepositoryFactory to pass factory=self to all supported repositories

## Benefits
- Enables better dependency injection and reduces tight coupling between repositories
- Improves testability and maintainability of repository layer
- Maintains backward compatibility with optional factory parameter

Fixes #323

🤖 Generated with [Claude Code](https://claude.ai/code)