### PR TITLE
Add individual factor repositories for all factor entities

### DIFF
--- a/example_individual_factor_repositories.py
+++ b/example_individual_factor_repositories.py
@@ -1,0 +1,95 @@
+"""
+Example demonstrating the use of individual factor repositories.
+This replaces the previous factory pattern approach with separate repositories.
+"""
+
+from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+
+# Import specific factor repositories
+from src.infrastructure.repositories.local_repo.factor import (
+    # Geographic repositories
+    ContinentFactorRepository,
+    CountryFactorRepository,
+    
+    # Financial asset repositories
+    IndexFactorRepository,
+    ShareMomentumFactorRepository,
+    ShareTechnicalFactorRepository,
+    ShareTargetFactorRepository,
+    ShareVolatilityFactorRepository,
+    DerivativeFactorRepository
+)
+
+# Import the registry for easy access
+from src.infrastructure.repositories.local_repo.factor.factor_repository_registry import FactorRepositoryRegistry
+
+# Import factor entities
+from src.domain.entities.factor.finance.financial_assets.index_factor import IndexFactor
+from src.domain.entities.factor.finance.financial_assets.share_factor.share_momentum_factor import ShareMomentumFactor
+
+
+def example_usage():
+    """Example of using individual factor repositories."""
+    
+    # Create a mock session (replace with actual session in real code)
+    engine = create_engine('sqlite:///:memory:')
+    session = Session(engine)
+    
+    print("=== Individual Factor Repository Examples ===\n")
+    
+    # Example 1: Direct repository usage
+    print("1. Direct Repository Usage:")
+    index_repo = IndexFactorRepository(session)
+    momentum_repo = ShareMomentumFactorRepository(session)
+    
+    print(f"   - Created IndexFactorRepository: {type(index_repo).__name__}")
+    print(f"   - Created ShareMomentumFactorRepository: {type(momentum_repo).__name__}")
+    
+    # Example 2: Using the registry to get repositories dynamically
+    print("\n2. Using FactorRepositoryRegistry:")
+    
+    # Get repository for IndexFactor
+    index_repo_from_registry = FactorRepositoryRegistry.get_repository(IndexFactor, session)
+    print(f"   - IndexFactor -> {type(index_repo_from_registry).__name__}")
+    
+    # Get repository for ShareMomentumFactor
+    momentum_repo_from_registry = FactorRepositoryRegistry.get_repository(ShareMomentumFactor, session)
+    print(f"   - ShareMomentumFactor -> {type(momentum_repo_from_registry).__name__}")
+    
+    # Example 3: Show all available mappings
+    print("\n3. All Available Factor Repository Mappings:")
+    mappings = FactorRepositoryRegistry.get_all_mappings()
+    for factor_class, repo_class in mappings.items():
+        print(f"   - {factor_class.__name__} -> {repo_class.__name__}")
+    
+    print(f"\n✅ Total factor repositories available: {len(mappings)}")
+    
+    # Example 4: Usage in entity service (simplified)
+    print("\n4. Usage in Entity Service (Concept):")
+    print("""
+    # OLD PROBLEMATIC WAY:
+    entity_factor_class_input = ENTITY_FACTOR_MAPPING[entity.__class__][0]
+    factor = self.entity_service._create_or_get(
+        entity_cls=Factor,
+        entity_factor_class_input=entity_factor_class_input  # ❌ Confusing parameter
+    )
+
+    # NEW CLEAN WAY WITH INDIVIDUAL REPOSITORIES:
+    factor_entity_class = ENTITY_FACTOR_MAPPING[entity.__class__][0]
+    factor_repo = FactorRepositoryRegistry.get_repository(factor_entity_class, session)
+    factor = factor_repo.get_or_create(
+        primary_key=factor_name,
+        group='price',
+        subgroup='daily',
+        data_type='numeric',
+        source='market_data'
+    )
+    """)
+    
+    session.close()
+    print("\n✅ Individual factor repositories working correctly!")
+
+
+if __name__ == "__main__":
+    example_usage()

--- a/src/infrastructure/repositories/local_repo/factor/__init__.py
+++ b/src/infrastructure/repositories/local_repo/factor/__init__.py
@@ -1,0 +1,64 @@
+"""
+Factor repositories package.
+"""
+
+from .base_factor_repository import BaseFactorRepository
+from .factor_repository import FactorRepository
+from .factor_value_repository import FactorValueRepository
+
+# Geographic factor repositories
+from .geographic import (
+    ContinentFactorRepository,
+    CountryFactorRepository
+)
+
+# Financial asset factor repositories
+from .finance.financial_assets import (
+    BondFactorRepository,
+    CommodityFactorRepository,
+    CompanyShareFactorRepository,
+    CurrencyFactorRepository,
+    DerivativeFactorRepository,
+    EquityFactorRepository,
+    EtfShareFactorRepository,
+    FinancialAssetFactorRepository,
+    FuturesFactorRepository,
+    IndexFactorRepository,
+    OptionsFactorRepository,
+    SecurityFactorRepository,
+    ShareFactorRepository,
+    ShareMomentumFactorRepository,
+    ShareTechnicalFactorRepository,
+    ShareTargetFactorRepository,
+    ShareVolatilityFactorRepository
+)
+
+__all__ = [
+    # Base repositories
+    'BaseFactorRepository',
+    'FactorRepository',
+    'FactorValueRepository',
+    
+    # Geographic repositories
+    'ContinentFactorRepository',
+    'CountryFactorRepository',
+    
+    # Financial asset repositories
+    'BondFactorRepository',
+    'CommodityFactorRepository',
+    'CompanyShareFactorRepository',
+    'CurrencyFactorRepository',
+    'DerivativeFactorRepository',
+    'EquityFactorRepository',
+    'EtfShareFactorRepository',
+    'FinancialAssetFactorRepository',
+    'FuturesFactorRepository',
+    'IndexFactorRepository',
+    'OptionsFactorRepository',
+    'SecurityFactorRepository',
+    'ShareFactorRepository',
+    'ShareMomentumFactorRepository',
+    'ShareTechnicalFactorRepository',
+    'ShareTargetFactorRepository',
+    'ShareVolatilityFactorRepository'
+]

--- a/src/infrastructure/repositories/local_repo/factor/factor_repository_registry.py
+++ b/src/infrastructure/repositories/local_repo/factor/factor_repository_registry.py
@@ -1,0 +1,139 @@
+"""
+Registry for mapping factor entity types to their corresponding repository classes.
+"""
+
+from typing import Type, Dict
+from sqlalchemy.orm import Session
+
+# Import all factor repositories
+from .geographic.continent_factor_repository import ContinentFactorRepository
+from .geographic.country_factor_repository import CountryFactorRepository
+from .finance.financial_assets.financial_asset_factor_repository import FinancialAssetFactorRepository
+from .finance.financial_assets.security_factor_repository import SecurityFactorRepository
+from .finance.financial_assets.index_factor_repository import IndexFactorRepository
+from .finance.financial_assets.currency_factor_repository import CurrencyFactorRepository
+from .finance.financial_assets.equity_factor_repository import EquityFactorRepository
+from .finance.financial_assets.share_factor_repository import ShareFactorRepository
+from .finance.financial_assets.share_momentum_factor_repository import ShareMomentumFactorRepository
+from .finance.financial_assets.share_technical_factor_repository import ShareTechnicalFactorRepository
+from .finance.financial_assets.share_target_factor_repository import ShareTargetFactorRepository
+from .finance.financial_assets.share_volatility_factor_repository import ShareVolatilityFactorRepository
+from .finance.financial_assets.bond_factor_repository import BondFactorRepository
+from .finance.financial_assets.derivative_factor_repository import DerivativeFactorRepository
+from .finance.financial_assets.options_factor_repository import OptionsFactorRepository
+from .finance.financial_assets.futures_factor_repository import FuturesFactorRepository
+
+# Import factor entity types
+from src.domain.entities.factor.continent_factor import ContinentFactor
+from src.domain.entities.factor.country_factor import CountryFactor
+from src.domain.entities.factor.finance.financial_assets.financial_asset_factor import FinancialAssetFactor
+from src.domain.entities.factor.finance.financial_assets.security_factor import SecurityFactor
+from src.domain.entities.factor.finance.financial_assets.index_factor import IndexFactor
+from src.domain.entities.factor.finance.financial_assets.currency_factor import CurrencyFactor
+from src.domain.entities.factor.finance.financial_assets.equity_factor import EquityFactor
+from src.domain.entities.factor.finance.financial_assets.share_factor.share_factor import ShareFactor
+from src.domain.entities.factor.finance.financial_assets.share_factor.share_momentum_factor import ShareMomentumFactor
+from src.domain.entities.factor.finance.financial_assets.share_factor.share_technical_factor import ShareTechnicalFactor
+from src.domain.entities.factor.finance.financial_assets.share_factor.share_target_factor import ShareTargetFactor
+from src.domain.entities.factor.finance.financial_assets.share_factor.share_volatility_factor import ShareVolatilityFactor
+from src.domain.entities.factor.finance.financial_assets.bond_factor.bond_factor import BondFactor
+from src.domain.entities.factor.finance.financial_assets.derivatives.derivative_factor import DerivativeFactor
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.option_factor import OptionFactor
+from src.domain.entities.factor.finance.financial_assets.derivatives.future.future_factor import FutureFactor
+
+from .base_factor_repository import BaseFactorRepository
+
+
+# Factor Entity to Repository Class Mapping
+FACTOR_REPOSITORY_MAPPING: Dict[Type, Type[BaseFactorRepository]] = {
+    # Geographic factors
+    ContinentFactor: ContinentFactorRepository,
+    CountryFactor: CountryFactorRepository,
+    
+    # Financial asset factors
+    FinancialAssetFactor: FinancialAssetFactorRepository,
+    SecurityFactor: SecurityFactorRepository,
+    IndexFactor: IndexFactorRepository,
+    CurrencyFactor: CurrencyFactorRepository,
+    EquityFactor: EquityFactorRepository,
+    
+    # Share factors
+    ShareFactor: ShareFactorRepository,
+    ShareMomentumFactor: ShareMomentumFactorRepository,
+    ShareTechnicalFactor: ShareTechnicalFactorRepository,
+    ShareTargetFactor: ShareTargetFactorRepository,
+    ShareVolatilityFactor: ShareVolatilityFactorRepository,
+    
+    # Bond factors
+    BondFactor: BondFactorRepository,
+    
+    # Derivative factors
+    DerivativeFactor: DerivativeFactorRepository,
+    OptionFactor: OptionsFactorRepository,
+    FutureFactor: FuturesFactorRepository,
+}
+
+
+class FactorRepositoryRegistry:
+    """Registry for getting the appropriate repository for a given factor entity type."""
+    
+    @staticmethod
+    def get_repository(factor_entity_class: Type, session: Session) -> BaseFactorRepository:
+        """
+        Get the appropriate repository instance for a given factor entity class.
+        
+        Args:
+            factor_entity_class: The factor entity class (e.g., IndexFactor)
+            session: Database session
+            
+        Returns:
+            Repository instance for the given factor entity type
+            
+        Raises:
+            KeyError: If no repository is registered for the given factor entity class
+        """
+        if factor_entity_class not in FACTOR_REPOSITORY_MAPPING:
+            raise KeyError(f"No repository registered for factor entity class: {factor_entity_class}")
+        
+        repository_class = FACTOR_REPOSITORY_MAPPING[factor_entity_class]
+        return repository_class(session)
+    
+    @staticmethod
+    def get_repository_class(factor_entity_class: Type) -> Type[BaseFactorRepository]:
+        """
+        Get the repository class (not instance) for a given factor entity class.
+        
+        Args:
+            factor_entity_class: The factor entity class
+            
+        Returns:
+            Repository class for the given factor entity type
+            
+        Raises:
+            KeyError: If no repository is registered for the given factor entity class
+        """
+        if factor_entity_class not in FACTOR_REPOSITORY_MAPPING:
+            raise KeyError(f"No repository registered for factor entity class: {factor_entity_class}")
+        
+        return FACTOR_REPOSITORY_MAPPING[factor_entity_class]
+    
+    @staticmethod
+    def get_all_mappings() -> Dict[Type, Type[BaseFactorRepository]]:
+        """
+        Get all factor entity to repository class mappings.
+        
+        Returns:
+            Dictionary of all mappings
+        """
+        return FACTOR_REPOSITORY_MAPPING.copy()
+    
+    @staticmethod
+    def register_repository(factor_entity_class: Type, repository_class: Type[BaseFactorRepository]) -> None:
+        """
+        Register a new factor entity to repository mapping.
+        
+        Args:
+            factor_entity_class: The factor entity class
+            repository_class: The repository class for this entity
+        """
+        FACTOR_REPOSITORY_MAPPING[factor_entity_class] = repository_class

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/__init__.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/__init__.py
@@ -1,0 +1,41 @@
+"""
+Financial asset factor repositories package.
+"""
+
+from .bond_factor_repository import BondFactorRepository
+from .commodity_factor_repository import CommodityFactorRepository
+from .company_share_factor_repository import CompanyShareFactorRepository
+from .currency_factor_repository import CurrencyFactorRepository
+from .derivative_factor_repository import DerivativeFactorRepository
+from .equity_factor_repository import EquityFactorRepository
+from .etf_share_factor_repository import EtfShareFactorRepository
+from .financial_asset_factor_repository import FinancialAssetFactorRepository
+from .futures_factor_repository import FuturesFactorRepository
+from .index_factor_repository import IndexFactorRepository
+from .options_factor_repository import OptionsFactorRepository
+from .security_factor_repository import SecurityFactorRepository
+from .share_factor_repository import ShareFactorRepository
+from .share_momentum_factor_repository import ShareMomentumFactorRepository
+from .share_technical_factor_repository import ShareTechnicalFactorRepository
+from .share_target_factor_repository import ShareTargetFactorRepository
+from .share_volatility_factor_repository import ShareVolatilityFactorRepository
+
+__all__ = [
+    'BondFactorRepository',
+    'CommodityFactorRepository',
+    'CompanyShareFactorRepository',
+    'CurrencyFactorRepository',
+    'DerivativeFactorRepository',
+    'EquityFactorRepository',
+    'EtfShareFactorRepository',
+    'FinancialAssetFactorRepository',
+    'FuturesFactorRepository',
+    'IndexFactorRepository',
+    'OptionsFactorRepository',
+    'SecurityFactorRepository',
+    'ShareFactorRepository',
+    'ShareMomentumFactorRepository',
+    'ShareTechnicalFactorRepository',
+    'ShareTargetFactorRepository',
+    'ShareVolatilityFactorRepository'
+]

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivative_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivative_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Derivative factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class DerivativeFactorRepository(BaseFactorRepository):
+    """Repository for Derivative factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a derivative factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'derivative'),
+                subgroup=kwargs.get('subgroup', 'general'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'market_data'),
+                definition=kwargs.get('definition', f'Derivative factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'derivative')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for derivative factor {primary_key}: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/financial_asset_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/financial_asset_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Financial Asset factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class FinancialAssetFactorRepository(BaseFactorRepository):
+    """Repository for Financial Asset factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a financial asset factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'financial_asset'),
+                subgroup=kwargs.get('subgroup', 'general'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'financial_data'),
+                definition=kwargs.get('definition', f'Financial asset factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'financial_asset')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for financial asset factor {primary_key}: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_momentum_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_momentum_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Share Momentum factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class ShareMomentumFactorRepository(BaseFactorRepository):
+    """Repository for Share Momentum factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a share momentum factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'momentum'),
+                subgroup=kwargs.get('subgroup', 'share'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'market_data'),
+                definition=kwargs.get('definition', f'Share momentum factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'share_momentum')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for share momentum factor {primary_key}: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_target_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_target_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Share Target factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class ShareTargetFactorRepository(BaseFactorRepository):
+    """Repository for Share Target factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a share target factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'target'),
+                subgroup=kwargs.get('subgroup', 'share'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'analyst_estimates'),
+                definition=kwargs.get('definition', f'Share target factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'share_target')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for share target factor {primary_key}: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_technical_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_technical_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Share Technical factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class ShareTechnicalFactorRepository(BaseFactorRepository):
+    """Repository for Share Technical factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a share technical factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'technical'),
+                subgroup=kwargs.get('subgroup', 'share'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'technical_analysis'),
+                definition=kwargs.get('definition', f'Share technical factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'share_technical')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for share technical factor {primary_key}: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_volatility_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share_volatility_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Share Volatility factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class ShareVolatilityFactorRepository(BaseFactorRepository):
+    """Repository for Share Volatility factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a share volatility factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'volatility'),
+                subgroup=kwargs.get('subgroup', 'share'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'market_data'),
+                definition=kwargs.get('definition', f'Share volatility factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'share_volatility')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for share volatility factor {primary_key}: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/geographic/__init__.py
+++ b/src/infrastructure/repositories/local_repo/factor/geographic/__init__.py
@@ -1,0 +1,11 @@
+"""
+Geographic factor repositories package.
+"""
+
+from .continent_factor_repository import ContinentFactorRepository
+from .country_factor_repository import CountryFactorRepository
+
+__all__ = [
+    'ContinentFactorRepository',
+    'CountryFactorRepository'
+]

--- a/src/infrastructure/repositories/local_repo/factor/geographic/continent_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/geographic/continent_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Continent factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ..base_factor_repository import BaseFactorRepository
+
+
+class ContinentFactorRepository(BaseFactorRepository):
+    """Repository for Continent factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a continent factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'geographic'),
+                subgroup=kwargs.get('subgroup', 'continent'),
+                data_type=kwargs.get('data_type', 'categorical'),
+                source=kwargs.get('source', 'geographic_data'),
+                definition=kwargs.get('definition', f'Continent factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'continent')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for continent factor {primary_key}: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/geographic/country_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/geographic/country_factor_repository.py
@@ -1,0 +1,59 @@
+"""
+Repository class for Country factor entities.
+"""
+
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ..base_factor_repository import BaseFactorRepository
+
+
+class CountryFactorRepository(BaseFactorRepository):
+    """Repository for Country factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def get_factor_model(self):
+        return FactorMapper().get_factor_model()
+    
+    def get_factor_entity(self):
+        return FactorMapper().get_factor_entity()
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a country factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_name(primary_key)
+            if existing:
+                return existing
+            
+            # Create new factor using base _create_or_get method
+            return self._create_or_get(
+                name=primary_key,
+                group=kwargs.get('group', 'geographic'),
+                subgroup=kwargs.get('subgroup', 'country'),
+                data_type=kwargs.get('data_type', 'categorical'),
+                source=kwargs.get('source', 'geographic_data'),
+                definition=kwargs.get('definition', f'Country factor: {primary_key}'),
+                entity_type=kwargs.get('entity_type', 'country')
+            )
+            
+        except Exception as e:
+            print(f"Error in get_or_create for country factor {primary_key}: {e}")
+            return None


### PR DESCRIPTION
Create separate repositories for each factor entity type as requested, abandoning the factory pattern approach.

## New Repositories Created:
- **Geographic:** ContinentFactorRepository, CountryFactorRepository
- **Financial Assets:** FinancialAssetFactorRepository, DerivativeFactorRepository
- **Specialized Share:** ShareMomentumFactorRepository, ShareTechnicalFactorRepository, ShareTargetFactorRepository, ShareVolatilityFactorRepository

## Additional Features:
- FactorRepositoryRegistry for clean entity-to-repo mapping
- Updated __init__.py files with proper imports
- Example usage file demonstrating patterns
- All repositories inherit from BaseFactorRepository

## Coverage:
Provides individual repositories for all 16 factor entity types: ContinentFactor, CountryFactor, FinancialAssetFactor, SecurityFactor, IndexFactor, CurrencyFactor, EquityFactor, ShareFactor, ShareMomentumFactor, ShareTechnicalFactor, ShareTargetFactor, ShareVolatilityFactor, BondFactor, DerivativeFactor, OptionFactor, FutureFactor.

Closes #340

🤖 Generated with [Claude Code](https://claude.ai/code)