### PR TITLE
feat: add configurable IBKR parameters to MarketData services

### DIFF
--- a/src/application/services/misbuffet/data/market_data_service.py
+++ b/src/application/services/misbuffet/data/market_data_service.py
@@ -130,8 +130,13 @@ class MarketDataService:
                         'entity_cls': entity_factor_class_input
                     })
                 
-                # Use batch method to get/create factors
-                created_factors = self.entity_service.get_or_create_batch_ibkr(factors_data, entity_factor_class_input)
+                # Use batch method to get/create factors with seconds bar_size for point-in-time data
+                created_factors = self.entity_service.get_or_create_batch_ibkr(
+                    factors_data, entity_factor_class_input,
+                    what_to_show="TRADES",
+                    duration_str="1 D", 
+                    bar_size_setting="1 sec"
+                )
                 
                 if created_factors:
                     # Prepare batch data for factor values with metadata for bulk IBKR processing
@@ -144,8 +149,13 @@ class MarketDataService:
                             'time_date': point_in_time.strftime("%Y-%m-%d %H:%M:%S")
                         })
                     
-                    # Use optimized batch method to get factor values from IBKR bulk data
-                    factor_values = self.entity_service.get_or_create_batch_ibkr(factor_values_data, FactorValue)
+                    # Use optimized batch method to get factor values from IBKR bulk data with seconds bar_size
+                    factor_values = self.entity_service.get_or_create_batch_ibkr(
+                        factor_values_data, FactorValue,
+                        what_to_show="TRADES",
+                        duration_str="1 D",
+                        bar_size_setting="1 sec"
+                    )
                     
                     # Build factor_data dictionary
                     for factor_value in factor_values:


### PR DESCRIPTION
Add configurable IBKR parameters to MarketDataService and MarketDataHistoryService as requested in issue #361.

## Changes
- Update MarketDataService._get_point_in_time_data to always use 1 sec bar_size
- Add configurable what_to_show, duration_str, bar_size_setting parameters to MarketDataHistoryService
- Update get_history method to accept IBKR configuration options
- Pass IBKR parameters through to get_or_create_batch_ibkr calls
- Add comprehensive documentation for new IBKR parameters

## Benefits
- Point-in-time data uses maximum granularity (seconds)
- Historical data fully configurable for different use cases
- Backward compatible with sensible defaults
- Leverages IBKR bulk data optimization effectively

Resolves #361

🤖 Generated with [Claude Code](https://claude.ai/code)