### PR TITLE
refactor: update FactorDependencyRepository to use FactorDependencyMapper

### DIFF
--- a/src/infrastructure/repositories/local_repo/factor/factor_dependency_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/factor_dependency_repository.py
@@ -11,6 +11,7 @@ from sqlalchemy import and_
 from src.domain.entities.factor.factor_dependency import FactorDependency
 from src.domain.ports.factor.factor_dependency_port import FactorDependencyPort
 from src.infrastructure.models.factor.factor_dependency import FactorDependencyModel
+from src.infrastructure.mappers.factor_dependency_mapper import FactorDependencyMapper
 from src.infrastructure.repositories.local_repo.base_repository import BaseLocalRepository
 
 
@@ -26,52 +27,36 @@ class FactorDependencyRepository(BaseLocalRepository[FactorDependency, FactorDep
         super().__init__(session)
         self.model_class = FactorDependencyModel
     
-    def _model_to_entity(self, model: FactorDependencyModel) -> FactorDependency:
-        """Convert SQLAlchemy model to domain entity."""
-        return FactorDependency(
-            id=model.id,
-            dependent_factor_id=model.dependent_factor_id,
-            independent_factor_id=model.independent_factor_id
-        )
-    
-    def _entity_to_model(self, entity: FactorDependency) -> FactorDependencyModel:
-        """Convert domain entity to SQLAlchemy model."""
-        return FactorDependencyModel(
-            id=entity.id,
-            dependent_factor_id=entity.dependent_factor_id,
-            independent_factor_id=entity.independent_factor_id
-        )
-    
     def get_by_id(self, entity_id: int) -> Optional[FactorDependency]:
         """Get factor dependency by ID."""
         model = self.get(entity_id)
-        return self._model_to_entity(model) if model else None
+        return FactorDependencyMapper.model_to_entity(model) if model else None
     
     def get_by_dependent_factor_id(self, dependent_factor_id: int) -> List[FactorDependency]:
         """Get factor dependencies by dependent factor ID."""
         models = self.session.query(FactorDependencyModel).filter(
             FactorDependencyModel.dependent_factor_id == dependent_factor_id
         ).all()
-        return [self._model_to_entity(model) for model in models]
+        return FactorDependencyMapper.models_to_entities(models)
     
     def get_by_independent_factor_id(self, independent_factor_id: int) -> List[FactorDependency]:
         """Get factor dependencies by independent factor ID."""
         models = self.session.query(FactorDependencyModel).filter(
             FactorDependencyModel.independent_factor_id == independent_factor_id
         ).all()
-        return [self._model_to_entity(model) for model in models]
+        return FactorDependencyMapper.models_to_entities(models)
     
     def get_all(self) -> List[FactorDependency]:
         """Get all factor dependencies."""
         models = self.session.query(FactorDependencyModel).all()
-        return [self._model_to_entity(model) for model in models]
+        return FactorDependencyMapper.models_to_entities(models)
     
     def add(self, entity: FactorDependency) -> Optional[FactorDependency]:
         """Add/persist a factor dependency entity."""
         try:
-            model = self._entity_to_model(entity)
+            model = FactorDependencyMapper.entity_to_model(entity)
             persisted_model = super().add(model)
-            return self._model_to_entity(persisted_model)
+            return FactorDependencyMapper.model_to_entity(persisted_model)
         except Exception:
             self.session.rollback()
             return None
@@ -87,7 +72,7 @@ class FactorDependencyRepository(BaseLocalRepository[FactorDependency, FactorDep
                 'independent_factor_id': entity.independent_factor_id
             }
             updated_model = super().update(entity.id, updates)
-            return self._model_to_entity(updated_model) if updated_model else None
+            return FactorDependencyMapper.model_to_entity(updated_model) if updated_model else None
         except Exception:
             self.session.rollback()
             return None


### PR DESCRIPTION
Update FactorDependencyRepository to properly use FactorDependencyMapper for all entity/model conversions as requested in issue #369

Key changes:
- Remove duplicate _model_to_entity() and _entity_to_model() methods
- Use dedicated mapper for all entity/model conversions
- Improves DDD separation of concerns and eliminates code duplication
- All CRUD operations now use centralized mapping logic

Follows DDD best practices with clear separation between repository (data access) and mapper (conversion) responsibilities.

Generated with [Claude Code](https://claude.ai/code)