### PR TITLE
Transform factor config from dict to list format

### DIFF
--- a/src/application/managers/project_managers/market_making_SPX_call_spread_project/config.py
+++ b/src/application/managers/project_managers/market_making_SPX_call_spread_project/config.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from src.domain.entities.finance.financial_assets.derivatives.future.index_future import IndexFuture
 from src.domain.entities.finance.financial_assets.index.index import Index
+from src.application.services.data.entities.factor.factor_library.factor_definition_config import FACTOR_LIBRARY
 # Base configuration
 BASE_PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent.parent
 DATA_PATH = BASE_PROJECT_ROOT / "data"
@@ -76,36 +77,34 @@ DEFAULT_CONFIG = {
     'validation_split': 0.2,
     'test_split': 0.2,
     
-    # Factors for modeling
-    # Factors for modeling
-    'factors' : {
-        'price_factors': [
-            {'name': 'open',   'group': 'price', 'subgroup': 'minutes', 'data_type': 'numeric'},
-            {'name': 'high',   'group': 'price', 'subgroup': 'minutes', 'data_type': 'numeric'},
-            {'name': 'low',    'group': 'price', 'subgroup': 'minutes', 'data_type': 'numeric'},
-            {'name': 'close',  'group': 'price', 'subgroup': 'minutes', 'data_type': 'numeric'},
-            {'name': 'volume', 'group': 'price', 'subgroup': 'minutes', 'data_type': 'numeric'},
-        ],
-        'technical_factors': [
-            {'name': 'sma_10',   'group': 'technical', 'subgroup': 'trend', 'data_type': 'numeric'},
-            {'name': 'sma_20',   'group': 'technical', 'subgroup': 'trend', 'data_type': 'numeric'},
-            {'name': 'rsi',      'group': 'technical', 'subgroup': 'momentum', 'data_type': 'numeric'},
-            {'name': 'macd',     'group': 'technical', 'subgroup': 'momentum', 'data_type': 'numeric'},
-            {'name': 'bb_upper', 'group': 'technical', 'subgroup': 'volatility', 'data_type': 'numeric'},
-            {'name': 'bb_lower', 'group': 'technical', 'subgroup': 'volatility', 'data_type': 'numeric'},
-        ],
-        'volatility_factors': [
-            {'name': 'realized_vol_10', 'group': 'volatility', 'subgroup': 'realized', 'data_type': 'numeric'},
-            {'name': 'realized_vol_20', 'group': 'volatility', 'subgroup': 'realized', 'data_type': 'numeric'},
-            {'name': 'vix',             'group': 'volatility', 'subgroup': 'implied', 'data_type': 'numeric'},
-            {'name': 'term_structure',  'group': 'volatility', 'subgroup': 'term_structure', 'data_type': 'numeric'},
-        ],
-        'market_factors': [
-            {'name': 'put_call_ratio',       'group': 'market', 'subgroup': 'sentiment', 'data_type': 'numeric'},
-            {'name': 'skew',                 'group': 'market', 'subgroup': 'options', 'data_type': 'numeric'},
-            {'name': 'term_structure_slope', 'group': 'market', 'subgroup': 'rates', 'data_type': 'numeric'},
-        ],
-    },
+    # Factors for modeling - transformed to list format using FACTOR_LIBRARY
+    'factors': [
+        # Price factors from future_index_library
+        FACTOR_LIBRARY["future_index_library"]["open"],
+        FACTOR_LIBRARY["future_index_library"]["high"],
+        FACTOR_LIBRARY["future_index_library"]["low"],
+        FACTOR_LIBRARY["future_index_library"]["close"],
+        FACTOR_LIBRARY["future_index_library"]["volume"],
+        
+        # Technical factors
+        FACTOR_LIBRARY["technical_library"]["sma_10"],
+        FACTOR_LIBRARY["technical_library"]["sma_20"],
+        FACTOR_LIBRARY["technical_library"]["rsi"],
+        FACTOR_LIBRARY["technical_library"]["macd"],
+        FACTOR_LIBRARY["technical_library"]["bb_upper"],
+        FACTOR_LIBRARY["technical_library"]["bb_lower"],
+        
+        # Volatility factors
+        FACTOR_LIBRARY["volatility_library"]["realized_vol_10"],
+        FACTOR_LIBRARY["volatility_library"]["realized_vol_20"],
+        FACTOR_LIBRARY["volatility_library"]["vix"],
+        FACTOR_LIBRARY["volatility_library"]["term_structure"],
+        
+        # Market factors
+        FACTOR_LIBRARY["market_library"]["put_call_ratio"],
+        FACTOR_LIBRARY["market_library"]["skew"],
+        FACTOR_LIBRARY["market_library"]["term_structure_slope"],
+    ],
 
     
     

--- a/src/application/services/data/entities/factor/factor_library/factor_definition_config.py
+++ b/src/application/services/data/entities/factor/factor_library/factor_definition_config.py
@@ -7,11 +7,128 @@ from typing import Dict, List
 from src.application.services.data.entities.factor.factor_library.finance.financial_assets.index_library import INDEX_LIBRARY
 from src.application.services.data.entities.factor.factor_library.finance.financial_assets.derivatives.future.future_index_library import FUTURE_INDEX_LIBRARY
 
+# Technical indicators library
+TECHNICAL_LIBRARY: Dict[str, Dict] = {
+    "sma_10": {
+        "group": "technical",
+        "subgroup": "trend",
+        "data_type": "numeric",
+        "description": "Simple Moving Average (10 periods)",
+        "dependencies": ["close"],
+        "parameters": {"period": 10}
+    },
+    "sma_20": {
+        "group": "technical",
+        "subgroup": "trend",
+        "data_type": "numeric",
+        "description": "Simple Moving Average (20 periods)",
+        "dependencies": ["close"],
+        "parameters": {"period": 20}
+    },
+    "rsi": {
+        "group": "technical",
+        "subgroup": "momentum",
+        "data_type": "numeric",
+        "description": "Relative Strength Index",
+        "dependencies": ["close"],
+        "parameters": {"period": 14}
+    },
+    "macd": {
+        "group": "technical",
+        "subgroup": "momentum",
+        "data_type": "numeric",
+        "description": "MACD indicator",
+        "dependencies": ["close"],
+        "parameters": {"fast_period": 12, "slow_period": 26, "signal_period": 9}
+    },
+    "bb_upper": {
+        "group": "technical",
+        "subgroup": "volatility",
+        "data_type": "numeric",
+        "description": "Upper Bollinger Band",
+        "dependencies": ["close"],
+        "parameters": {"period": 20, "std_dev_multiplier": 2}
+    },
+    "bb_lower": {
+        "group": "technical",
+        "subgroup": "volatility",
+        "data_type": "numeric",
+        "description": "Lower Bollinger Band",
+        "dependencies": ["close"],
+        "parameters": {"period": 20, "std_dev_multiplier": 2}
+    },
+}
+
+# Volatility factors library
+VOLATILITY_LIBRARY: Dict[str, Dict] = {
+    "realized_vol_10": {
+        "group": "volatility",
+        "subgroup": "realized",
+        "data_type": "numeric",
+        "description": "Realized volatility over 10 periods",
+        "dependencies": ["close"],
+        "parameters": {"lookback": 10}
+    },
+    "realized_vol_20": {
+        "group": "volatility",
+        "subgroup": "realized",
+        "data_type": "numeric",
+        "description": "Realized volatility over 20 periods",
+        "dependencies": ["close"],
+        "parameters": {"lookback": 20}
+    },
+    "vix": {
+        "group": "volatility",
+        "subgroup": "implied",
+        "data_type": "numeric",
+        "description": "VIX (implied volatility index)",
+        "dependencies": [],
+        "parameters": {}
+    },
+    "term_structure": {
+        "group": "volatility",
+        "subgroup": "term_structure",
+        "data_type": "numeric",
+        "description": "Volatility term structure",
+        "dependencies": [],
+        "parameters": {}
+    },
+}
+
+# Market factors library
+MARKET_LIBRARY: Dict[str, Dict] = {
+    "put_call_ratio": {
+        "group": "market",
+        "subgroup": "sentiment",
+        "data_type": "numeric",
+        "description": "Put/Call ratio",
+        "dependencies": [],
+        "parameters": {}
+    },
+    "skew": {
+        "group": "market",
+        "subgroup": "options",
+        "data_type": "numeric",
+        "description": "Options skew",
+        "dependencies": [],
+        "parameters": {}
+    },
+    "term_structure_slope": {
+        "group": "market",
+        "subgroup": "rates",
+        "data_type": "numeric",
+        "description": "Term structure slope",
+        "dependencies": [],
+        "parameters": {}
+    },
+}
+
 FACTOR_LIBRARY: Dict[str, Dict] = {
-    "future_index_library":{FUTURE_INDEX_LIBRARY},
-    "index_library":{INDEX_LIBRARY}
-    
-    
+    "future_index_library": FUTURE_INDEX_LIBRARY,
+    "index_library": INDEX_LIBRARY,
+    "technical_library": TECHNICAL_LIBRARY,
+    "volatility_library": VOLATILITY_LIBRARY,
+    "market_library": MARKET_LIBRARY,
 }
 
 
@@ -21,140 +138,3 @@ def get_factor_config(name: str) -> Dict:
     """
     return FACTOR_LIBRARY.get(name, {})
 
-
-
-#     # --------------------------
-#     # Technical indicators
-#     # --------------------------
-#     "sma_10": {
-#         "group": "technical",
-#         "subgroup": "trend",
-#         "data_type": "numeric",
-#         "description": "Simple Moving Average (10 periods)",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "period": 10
-#         }
-#     },
-#     "sma_20": {
-#         "group": "technical",
-#         "subgroup": "trend",
-#         "data_type": "numeric",
-#         "description": "Simple Moving Average (20 periods)",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "period": 20
-#         }
-#     },
-#     "rsi": {
-#         "group": "technical",
-#         "subgroup": "momentum",
-#         "data_type": "numeric",
-#         "description": "Relative Strength Index",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "period": 14
-#         }
-#     },
-#     "macd": {
-#         "group": "technical",
-#         "subgroup": "momentum",
-#         "data_type": "numeric",
-#         "description": "MACD indicator",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "fast_period": 12,
-#             "slow_period": 26,
-#             "signal_period": 9
-#         }
-#     },
-#     "bb_upper": {
-#         "group": "technical",
-#         "subgroup": "volatility",
-#         "data_type": "numeric",
-#         "description": "Upper Bollinger Band",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "period": 20,
-#             "std_dev_multiplier": 2
-#         }
-#     },
-#     "bb_lower": {
-#         "group": "technical",
-#         "subgroup": "volatility",
-#         "data_type": "numeric",
-#         "description": "Lower Bollinger Band",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "period": 20,
-#             "std_dev_multiplier": 2
-#         }
-#     },
-
-#     # --------------------------
-#     # Volatility measures
-#     # --------------------------
-#     "realized_vol_10": {
-#         "group": "volatility",
-#         "subgroup": "realized",
-#         "data_type": "numeric",
-#         "description": "Realized volatility over 10 periods",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "lookback": 10
-#         }
-#     },
-#     "realized_vol_20": {
-#         "group": "volatility",
-#         "subgroup": "realized",
-#         "data_type": "numeric",
-#         "description": "Realized volatility over 20 periods",
-#         "dependencies": ["close"],
-#         "parameters": {
-#             "lookback": 20
-#         }
-#     },
-#     "vix": {
-#         "group": "volatility",
-#         "subgroup": "implied",
-#         "data_type": "numeric",
-#         "description": "VIX (implied volatility index)",
-#         "dependencies": [],
-#         "parameters": {}
-#     },
-#     "term_structure": {
-#         "group": "volatility",
-#         "subgroup": "term_structure",
-#         "data_type": "numeric",
-#         "description": "Volatility term structure",
-#         "dependencies": [],
-#         "parameters": {}
-#     },
-
-#     # --------------------------
-#     # Market-wide factors
-#     # --------------------------
-#     "put_call_ratio": {
-#         "group": "market",
-#         "subgroup": "sentiment",
-#         "data_type": "numeric",
-#         "description": "Put/Call ratio",
-#         "dependencies": [],
-#         "parameters": {}
-#     },
-#     "skew": {
-#         "group": "market",
-#         "subgroup": "options",
-#         "data_type": "numeric",
-#         "description": "Options skew",
-#         "dependencies": [],
-#         "parameters": {}
-#     },
-#     "term_structure_slope": {
-#         "group": "market",
-#         "subgroup": "rates",
-#         "data_type": "numeric",
-#         "description": "Term structure slope",
-#         "dependencies": [],
-#         "parameters": {}
-#     }


### PR DESCRIPTION
Transform factor config in market making SPX call spread project from dict format to list format using FACTOR_LIBRARY references.

## Changes
- Convert factors dict to list format using FACTOR_LIBRARY references
- Transfer factor configurations from config.py to factor_definition_config.py
- Add technical_library, volatility_library, and market_library to FACTOR_LIBRARY
- Update factors to reference FACTOR_LIBRARY["future_index_library"]["open"] format
- Remove duplicate factor definitions and organize in centralized library

Closes #379

Generated with [Claude Code](https://claude.ai/code)