### PR TITLE
Add index and future return factors (daily, weekly, monthly)

### DIFF
--- a/src/application/managers/project_managers/market_making_SPX_call_spread_project/config.py
+++ b/src/application/managers/project_managers/market_making_SPX_call_spread_project/config.py
@@ -86,6 +86,16 @@ DEFAULT_CONFIG = {
         FACTOR_LIBRARY["future_index_library"]["close"],
         FACTOR_LIBRARY["future_index_library"]["volume"],
         
+        # Future return factors (daily, weekly, monthly)
+        FACTOR_LIBRARY["future_index_library"]["return_daily"],
+        FACTOR_LIBRARY["future_index_library"]["return_weekly"],
+        FACTOR_LIBRARY["future_index_library"]["return_monthly"],
+        
+        # Index return factors (daily, weekly, monthly)
+        FACTOR_LIBRARY["index_library"]["return_daily"],
+        FACTOR_LIBRARY["index_library"]["return_weekly"],
+        FACTOR_LIBRARY["index_library"]["return_monthly"],
+        
         # Technical factors
         FACTOR_LIBRARY["technical_library"]["sma_10"],
         FACTOR_LIBRARY["technical_library"]["sma_20"],

--- a/src/application/services/data/entities/factor/factor_library/finance/financial_assets/derivatives/future/future_index_library.py
+++ b/src/application/services/data/entities/factor/factor_library/finance/financial_assets/derivatives/future/future_index_library.py
@@ -71,4 +71,68 @@ FUTURE_INDEX_LIBRARY: Dict[str, Dict] = {
                 },
         "parameters": {}
     },
+    
+    # Daily return factors
+    "return_daily": {
+        "class": FuturePriceReturnFactor,
+        "group": "return",
+        "subgroup": "daily",
+        "data_type": "numeric",
+        "description": "Daily price return",
+        "dependencies": {
+            "close": {
+                "class": FutureFactor,
+                "group": "price",
+                "subgroup": "daily",
+                "data_type": "numeric",
+                "description": "Daily close price",
+                "dependencies": [],
+                "parameters": {}
+            },
+        },
+        "parameters": {"period": "1D"}
+    },
+    
+    # Weekly return factors
+    "return_weekly": {
+        "class": FuturePriceReturnFactor,
+        "group": "return",
+        "subgroup": "weekly",
+        "data_type": "numeric",
+        "description": "Weekly price return",
+        "dependencies": {
+            "close": {
+                "class": FutureFactor,
+                "group": "price",
+                "subgroup": "weekly",
+                "data_type": "numeric",
+                "description": "Weekly close price",
+                "dependencies": [],
+                "parameters": {}
+            },
+        },
+        "parameters": {"period": "1W"}
+    },
+    
+    # Monthly return factors
+    "return_monthly": {
+        "class": FuturePriceReturnFactor,
+        "group": "return",
+        "subgroup": "monthly",
+        "data_type": "numeric",
+        "description": "Monthly price return",
+        "dependencies": {
+            "close": {
+                "class": FutureFactor,
+                "group": "price",
+                "subgroup": "monthly",
+                "data_type": "numeric",
+                "description": "Monthly close price",
+                "dependencies": [],
+                "parameters": {}
+            },
+        },
+        "parameters": {"period": "1M"}
+    },
+    
 }

--- a/src/application/services/data/entities/factor/factor_library/finance/financial_assets/index_library.py
+++ b/src/application/services/data/entities/factor/factor_library/finance/financial_assets/index_library.py
@@ -70,4 +70,67 @@ INDEX_LIBRARY: Dict[str, Dict] = {
         "parameters": {}
     },
     
+    # Daily return factors
+    "return_daily": {
+        "class": IndexPriceReturnFactor,
+        "group": "return",
+        "subgroup": "daily",
+        "data_type": "numeric",
+        "description": "Daily price return",
+        "dependencies": {
+            "close": {
+                "class": IndexFactor,
+                "group": "price",
+                "subgroup": "daily",
+                "data_type": "numeric",
+                "description": "Daily close price",
+                "dependencies": [],
+                "parameters": {}
+            },
+        },
+        "parameters": {"period": "1D"}
+    },
+    
+    # Weekly return factors
+    "return_weekly": {
+        "class": IndexPriceReturnFactor,
+        "group": "return",
+        "subgroup": "weekly",
+        "data_type": "numeric",
+        "description": "Weekly price return",
+        "dependencies": {
+            "close": {
+                "class": IndexFactor,
+                "group": "price",
+                "subgroup": "weekly",
+                "data_type": "numeric",
+                "description": "Weekly close price",
+                "dependencies": [],
+                "parameters": {}
+            },
+        },
+        "parameters": {"period": "1W"}
+    },
+    
+    # Monthly return factors
+    "return_monthly": {
+        "class": IndexPriceReturnFactor,
+        "group": "return",
+        "subgroup": "monthly",
+        "data_type": "numeric",
+        "description": "Monthly price return",
+        "dependencies": {
+            "close": {
+                "class": IndexFactor,
+                "group": "price",
+                "subgroup": "monthly",
+                "data_type": "numeric",
+                "description": "Monthly close price",
+                "dependencies": [],
+                "parameters": {}
+            },
+        },
+        "parameters": {"period": "1M"}
+    },
+    
 }


### PR DESCRIPTION
Add index and future return factors (daily, weekly, monthly) to factor libraries and update config.

## Changes
- Added return_daily, return_weekly, return_monthly to INDEX_LIBRARY
- Added return_daily, return_weekly, return_monthly to FUTURE_INDEX_LIBRARY
- Updated config.py factors list to include new return factors
- Organized factors by category with proper dependencies and parameters

Closes #379

Generated with [Claude Code](https://claude.ai/code)