### PR TITLE
fix: remove trailing commas causing tuple assignment in IndexFutureMapper

### DIFF
--- a/src/infrastructure/repositories/mappers/finance/financial_assets/index_future_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/financial_assets/index_future_mapper.py
@@ -61,12 +61,12 @@ class IndexFutureMapper:
         # Identification
         orm_obj.symbol = domain_obj.symbol
         orm_obj.name = domain_obj.name
-        orm_obj.currency_id=domain_obj.currency_id if hasattr(domain_obj, 'currency_id') else None,
-        orm_obj.exchange_id=domain_obj.exchange_id if hasattr(domain_obj, 'exchange_id') else None,
-        orm_obj.underlying_asset_id=domain_obj.underlying_asset_id if hasattr(domain_obj, 'underlying_asset_id') else None,
-        orm_obj.start_date=domain_obj.start_date if hasattr(domain_obj, 'start_date') else None,
-        orm_obj.end_date=domain_obj.end_date if hasattr(domain_obj, 'end_date') else None,
-        orm_obj.contract_size=domain_obj.contract_size if hasattr(domain_obj, 'contract_size') else None,
+        orm_obj.currency_id = domain_obj.currency_id if hasattr(domain_obj, 'currency_id') else None
+        orm_obj.exchange_id = domain_obj.exchange_id if hasattr(domain_obj, 'exchange_id') else None
+        orm_obj.underlying_asset_id = domain_obj.underlying_asset_id if hasattr(domain_obj, 'underlying_asset_id') else None
+        orm_obj.start_date = domain_obj.start_date if hasattr(domain_obj, 'start_date') else None
+        orm_obj.end_date = domain_obj.end_date if hasattr(domain_obj, 'end_date') else None
+        orm_obj.contract_size = domain_obj.contract_size if hasattr(domain_obj, 'contract_size') else None
         
 
         return orm_obj


### PR DESCRIPTION
Fixed pyodbc error 'A TVP's rows must be Sequence objects' by removing trailing commas that were creating tuples (None,) instead of assigning None values directly to ORM object attributes in the to_orm method.

Fixes #395

Generated with [Claude Code](https://claude.ai/code)