### PR TITLE
feat: create index future option infrastructure components

### DIFF
--- a/src/infrastructure/models/factor/factor.py
+++ b/src/infrastructure/models/factor/factor.py
@@ -56,3 +56,28 @@ class IndexPriceReturnFactorModel(FactorModel):
     __mapper_args__ = {
         "polymorphic_identity": "index_price_return_factor"
     }
+
+
+# Index Future Option Factor Models
+class IndexFutureOptionFactorModel(FactorModel):
+    __mapper_args__ = {
+        "polymorphic_identity": "index_future_option_factor"
+    }
+
+
+class IndexFutureOptionPriceFactorModel(FactorModel):
+    __mapper_args__ = {
+        "polymorphic_identity": "index_future_option_price_factor"
+    }
+
+
+class IndexFutureOptionPriceReturnFactorModel(FactorModel):
+    __mapper_args__ = {
+        "polymorphic_identity": "index_future_option_price_return_factor"
+    }
+
+
+class IndexFutureOptionDeltaFactorModel(FactorModel):
+    __mapper_args__ = {
+        "polymorphic_identity": "index_future_option_delta_factor"
+    }

--- a/src/infrastructure/models/finance/financial_assets/derivative/option/index_future_option.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/option/index_future_option.py
@@ -1,0 +1,28 @@
+"""
+ORM model for Index Future Options - separate from src.domain entity to avoid metaclass conflicts.
+"""
+
+from sqlalchemy import Column, Integer, String, Numeric, ForeignKey
+from src.infrastructure.models.finance.financial_assets.derivative.options import OptionsModel
+
+
+class IndexFutureOptionModel(OptionsModel):
+    """
+    SQLAlchemy ORM model for Index Future Options.
+    Completely separate from src.domain entity to avoid metaclass conflicts.
+    """
+    __tablename__ = 'index_future_options'
+
+    id = Column(Integer, ForeignKey("options.id"), primary_key=True)
+    
+    # Index future option specific fields
+    strike_price = Column(Numeric(precision=15, scale=6), nullable=True)
+    multiplier = Column(Numeric(precision=10, scale=2), nullable=True, default=1.0)
+    index_symbol = Column(String(50), nullable=True)
+    
+    __mapper_args__ = {
+        "polymorphic_identity": "index_future_option",
+    }
+
+    def __repr__(self):
+        return f"<IndexFutureOption(id={self.id}, symbol={self.symbol}, strike={self.strike_price})>"

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_delta_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_delta_factor_repository.py
@@ -1,0 +1,130 @@
+"""
+Repository class for Index Future Option Delta factor entities.
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.index_future_option_delta_factor_mapper import IndexFutureOptionDeltaFactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class IndexFutureOptionDeltaFactorRepository(BaseFactorRepository):
+    """Repository for Index Future Option Delta factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session, factory=None):
+        super().__init__(session)
+        self.factory = factory
+        self.mapper = IndexFutureOptionDeltaFactorMapper()
+
+    @property
+    def entity_class(self):
+        return self.get_factor_entity()
+
+    def get_factor_model(self):
+        return self.mapper.get_factor_model()
+    
+    def get_factor_entity(self):
+        return self.mapper.get_factor_entity()
+
+    @property
+    def model_class(self):
+        return self.mapper.model_class
+
+    def get_by_id(self, id: int):
+        return (
+            self.session
+            .query(self.model_class)
+            .filter(self.model_class.id == id)
+            .one_or_none()
+        )
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def _to_entity(self, infra_obj):
+        """Convert ORM model to domain entity."""
+        return IndexFutureOptionDeltaFactorMapper.to_domain(infra_obj)
+    
+    def _to_model(self, entity):
+        """Convert domain entity to ORM model."""
+        return IndexFutureOptionDeltaFactorMapper.to_orm(entity)
+
+    def _create_or_get(self, primary_key: str, **kwargs):
+        """
+        Get or create an index future option delta factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_all(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'delta'),
+                factor_type=kwargs.get('factor_type', 'greek'),
+                data_type=self.mapper.discriminator,
+                source=kwargs.get('source', 'market_data')
+            )
+            if existing:
+                return self._to_entity(existing)
+
+            domain_factor = self.get_factor_entity()(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'delta'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'market_data'),
+                definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')
+            )
+            
+            # Use FactorMapper to convert domain entity to ORM model
+            orm_factor = self._to_model(domain_factor)
+            
+            self.session.add(orm_factor)
+            self.session.commit()
+            if orm_factor:
+                return self._to_entity(orm_factor)
+            
+        except Exception as e:
+            print(f"Error in get_or_create for index future option delta factor {primary_key}: {e}")
+            return None
+        
+    def get_by_all(
+        self,
+        name: str,
+        group: str,
+        factor_type: str = None,
+        subgroup: Optional[str] = None,
+        frequency: Optional[str] = None,
+        data_type: Optional[str] = None,
+        source: Optional[str] = None,
+    ):
+        """Retrieve a factor matching all non-id fields."""
+        try:
+            FactorModel = self.get_factor_model()
+
+            query = self.session.query(FactorModel).filter(
+                FactorModel.name == name,
+                FactorModel.group == group,
+                FactorModel.factor_type == factor_type,
+                FactorModel.subgroup == subgroup,
+                FactorModel.frequency == frequency,
+                FactorModel.data_type == data_type,
+                FactorModel.source == source,
+            )
+
+            factor = query.first()
+            return factor
+
+        except Exception as e:
+            print(f"Error retrieving index future option delta factor by all attributes: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_factor_repository.py
@@ -1,0 +1,130 @@
+"""
+Repository class for Index Future Option factor entities.
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.index_future_option_factor_mapper import IndexFutureOptionFactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class IndexFutureOptionFactorRepository(BaseFactorRepository):
+    """Repository for Index Future Option factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session, factory=None):
+        super().__init__(session)
+        self.factory = factory
+        self.mapper = IndexFutureOptionFactorMapper()
+
+    @property
+    def entity_class(self):
+        return self.get_factor_entity()
+
+    def get_factor_model(self):
+        return self.mapper.get_factor_model()
+    
+    def get_factor_entity(self):
+        return self.mapper.get_factor_entity()
+
+    @property
+    def model_class(self):
+        return self.mapper.model_class
+
+    def get_by_id(self, id: int):
+        return (
+            self.session
+            .query(self.model_class)
+            .filter(self.model_class.id == id)
+            .one_or_none()
+        )
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def _to_entity(self, infra_obj):
+        """Convert ORM model to domain entity."""
+        return IndexFutureOptionFactorMapper.to_domain(infra_obj)
+    
+    def _to_model(self, entity):
+        """Convert domain entity to ORM model."""
+        return IndexFutureOptionFactorMapper.to_orm(entity)
+
+    def _create_or_get(self, primary_key: str, **kwargs):
+        """
+        Get or create an index future option factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_all(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'daily'),
+                factor_type=kwargs.get('factor_type', 'option'),
+                data_type=self.mapper.discriminator,
+                source=kwargs.get('source', 'market_data')
+            )
+            if existing:
+                return self._to_entity(existing)
+
+            domain_factor = self.get_factor_entity()(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'daily'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'market_data'),
+                definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')
+            )
+            
+            # Use FactorMapper to convert domain entity to ORM model
+            orm_factor = self._to_model(domain_factor)
+            
+            self.session.add(orm_factor)
+            self.session.commit()
+            if orm_factor:
+                return self._to_entity(orm_factor)
+            
+        except Exception as e:
+            print(f"Error in get_or_create for index future option factor {primary_key}: {e}")
+            return None
+        
+    def get_by_all(
+        self,
+        name: str,
+        group: str,
+        factor_type: str = None,
+        subgroup: Optional[str] = None,
+        frequency: Optional[str] = None,
+        data_type: Optional[str] = None,
+        source: Optional[str] = None,
+    ):
+        """Retrieve a factor matching all non-id fields."""
+        try:
+            FactorModel = self.get_factor_model()
+
+            query = self.session.query(FactorModel).filter(
+                FactorModel.name == name,
+                FactorModel.group == group,
+                FactorModel.factor_type == factor_type,
+                FactorModel.subgroup == subgroup,
+                FactorModel.frequency == frequency,
+                FactorModel.data_type == data_type,
+                FactorModel.source == source,
+            )
+
+            factor = query.first()
+            return factor
+
+        except Exception as e:
+            print(f"Error retrieving index future option factor by all attributes: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_price_factor_repository.py
@@ -1,0 +1,130 @@
+"""
+Repository class for Index Future Option Price factor entities.
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.index_future_option_price_factor_mapper import IndexFutureOptionPriceFactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class IndexFutureOptionPriceFactorRepository(BaseFactorRepository):
+    """Repository for Index Future Option Price factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session, factory=None):
+        super().__init__(session)
+        self.factory = factory
+        self.mapper = IndexFutureOptionPriceFactorMapper()
+
+    @property
+    def entity_class(self):
+        return self.get_factor_entity()
+
+    def get_factor_model(self):
+        return self.mapper.get_factor_model()
+    
+    def get_factor_entity(self):
+        return self.mapper.get_factor_entity()
+
+    @property
+    def model_class(self):
+        return self.mapper.model_class
+
+    def get_by_id(self, id: int):
+        return (
+            self.session
+            .query(self.model_class)
+            .filter(self.model_class.id == id)
+            .one_or_none()
+        )
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def _to_entity(self, infra_obj):
+        """Convert ORM model to domain entity."""
+        return IndexFutureOptionPriceFactorMapper.to_domain(infra_obj)
+    
+    def _to_model(self, entity):
+        """Convert domain entity to ORM model."""
+        return IndexFutureOptionPriceFactorMapper.to_orm(entity)
+
+    def _create_or_get(self, primary_key: str, **kwargs):
+        """
+        Get or create an index future option price factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_all(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'price'),
+                factor_type=kwargs.get('factor_type', 'pricing'),
+                data_type=self.mapper.discriminator,
+                source=kwargs.get('source', 'market_data')
+            )
+            if existing:
+                return self._to_entity(existing)
+
+            domain_factor = self.get_factor_entity()(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'price'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'market_data'),
+                definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')
+            )
+            
+            # Use FactorMapper to convert domain entity to ORM model
+            orm_factor = self._to_model(domain_factor)
+            
+            self.session.add(orm_factor)
+            self.session.commit()
+            if orm_factor:
+                return self._to_entity(orm_factor)
+            
+        except Exception as e:
+            print(f"Error in get_or_create for index future option price factor {primary_key}: {e}")
+            return None
+        
+    def get_by_all(
+        self,
+        name: str,
+        group: str,
+        factor_type: str = None,
+        subgroup: Optional[str] = None,
+        frequency: Optional[str] = None,
+        data_type: Optional[str] = None,
+        source: Optional[str] = None,
+    ):
+        """Retrieve a factor matching all non-id fields."""
+        try:
+            FactorModel = self.get_factor_model()
+
+            query = self.session.query(FactorModel).filter(
+                FactorModel.name == name,
+                FactorModel.group == group,
+                FactorModel.factor_type == factor_type,
+                FactorModel.subgroup == subgroup,
+                FactorModel.frequency == frequency,
+                FactorModel.data_type == data_type,
+                FactorModel.source == source,
+            )
+
+            factor = query.first()
+            return factor
+
+        except Exception as e:
+            print(f"Error retrieving index future option price factor by all attributes: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_price_return_factor_repository.py
@@ -1,0 +1,130 @@
+"""
+Repository class for Index Future Option Price Return factor entities.
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.index_future_option_price_return_factor_mapper import IndexFutureOptionPriceReturnFactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class IndexFutureOptionPriceReturnFactorRepository(BaseFactorRepository):
+    """Repository for Index Future Option Price Return factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session, factory=None):
+        super().__init__(session)
+        self.factory = factory
+        self.mapper = IndexFutureOptionPriceReturnFactorMapper()
+
+    @property
+    def entity_class(self):
+        return self.get_factor_entity()
+
+    def get_factor_model(self):
+        return self.mapper.get_factor_model()
+    
+    def get_factor_entity(self):
+        return self.mapper.get_factor_entity()
+
+    @property
+    def model_class(self):
+        return self.mapper.model_class
+
+    def get_by_id(self, id: int):
+        return (
+            self.session
+            .query(self.model_class)
+            .filter(self.model_class.id == id)
+            .one_or_none()
+        )
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def _to_entity(self, infra_obj):
+        """Convert ORM model to domain entity."""
+        return IndexFutureOptionPriceReturnFactorMapper.to_domain(infra_obj)
+    
+    def _to_model(self, entity):
+        """Convert domain entity to ORM model."""
+        return IndexFutureOptionPriceReturnFactorMapper.to_orm(entity)
+
+    def _create_or_get(self, primary_key: str, **kwargs):
+        """
+        Get or create an index future option price return factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            Factor entity or None if creation failed
+        """
+        try:
+            # Check existing by primary identifier (factor name)
+            existing = self.get_by_all(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'return'),
+                factor_type=kwargs.get('factor_type', 'return'),
+                data_type=self.mapper.discriminator,
+                source=kwargs.get('source', 'market_data')
+            )
+            if existing:
+                return self._to_entity(existing)
+
+            domain_factor = self.get_factor_entity()(
+                name=primary_key,
+                group=kwargs.get('group', 'index_future_option'),
+                subgroup=kwargs.get('subgroup', 'return'),
+                data_type=kwargs.get('data_type', 'numeric'),
+                source=kwargs.get('source', 'market_data'),
+                definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')
+            )
+            
+            # Use FactorMapper to convert domain entity to ORM model
+            orm_factor = self._to_model(domain_factor)
+            
+            self.session.add(orm_factor)
+            self.session.commit()
+            if orm_factor:
+                return self._to_entity(orm_factor)
+            
+        except Exception as e:
+            print(f"Error in get_or_create for index future option price return factor {primary_key}: {e}")
+            return None
+        
+    def get_by_all(
+        self,
+        name: str,
+        group: str,
+        factor_type: str = None,
+        subgroup: Optional[str] = None,
+        frequency: Optional[str] = None,
+        data_type: Optional[str] = None,
+        source: Optional[str] = None,
+    ):
+        """Retrieve a factor matching all non-id fields."""
+        try:
+            FactorModel = self.get_factor_model()
+
+            query = self.session.query(FactorModel).filter(
+                FactorModel.name == name,
+                FactorModel.group == group,
+                FactorModel.factor_type == factor_type,
+                FactorModel.subgroup == subgroup,
+                FactorModel.frequency == frequency,
+                FactorModel.data_type == data_type,
+                FactorModel.source == source,
+            )
+
+            factor = query.first()
+            return factor
+
+        except Exception as e:
+            print(f"Error retrieving index future option price return factor by all attributes: {e}")
+            return None

--- a/src/infrastructure/repositories/local_repo/finance/financial_assets/derivatives/option/index_future_option_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/financial_assets/derivatives/option/index_future_option_repository.py
@@ -1,0 +1,121 @@
+"""
+IndexFutureOptionRepository for local database operations.
+Specialization of OptionsRepository for index future options.
+"""
+
+import logging
+from typing import Optional
+from sqlalchemy.orm import Session
+
+from src.domain.entities.finance.financial_assets.derivatives.option.index_future_option import IndexFutureOption
+from src.domain.ports.finance.financial_assets.derivatives.option.index_future_option_port import IndexFutureOptionPort
+from src.infrastructure.repositories.local_repo.finance.financial_assets.derivatives.options_repository import OptionsRepository
+from src.infrastructure.repositories.mappers.finance.financial_assets.index_future_option_mapper import IndexFutureOptionMapper
+
+logger = logging.getLogger(__name__)
+
+
+class IndexFutureOptionRepository(OptionsRepository, IndexFutureOptionPort):
+    """
+    Repository for Index Future Option instruments.
+    Specialization of OptionsRepository.
+    """
+
+    def __init__(self, session: Session, factory):
+        """Initialize IndexFutureOptionRepository with database session."""
+        super().__init__(session, factory)
+        self.mapper = IndexFutureOptionMapper()
+
+    @property
+    def entity_class(self):
+        """Return the domain entity class for IndexFutureOption."""
+        return self.mapper.entity_class
+    
+    @property
+    def model_class(self):
+        """Return the SQLAlchemy model class for IndexFutureOption."""
+        return self.mapper.model_class
+
+    def get_by_id(self, id: int):
+        """Get index future option by ID."""
+        return (
+            self.session
+            .query(self.model_class)
+            .filter(self.model_class.id == id)
+            .one_or_none()
+        )
+
+    # ------------------------------------------------------------------
+    # Index Future Option-specific queries
+    # ------------------------------------------------------------------
+
+    def get_by_index_symbol(self, index_symbol: str) -> Optional[IndexFutureOption]:
+        """
+        Fetch an Index Future Option by index symbol.
+        
+        Args:
+            index_symbol: The underlying index symbol (e.g., 'SPX', 'NDX')
+            
+        Returns:
+            IndexFutureOption entity or None if not found
+        """
+        try:
+            option = (
+                self.session.query(self.model_class)
+                .filter(self.model_class.index_symbol == index_symbol)
+                .first()
+            )
+            return self.mapper.to_domain(option) if option else None
+        except Exception as e:
+            logger.error(f"Error retrieving index future option by index symbol {index_symbol}: {e}")
+            return None
+
+    def get_by_strike_and_index(self, strike_price: float, index_symbol: str) -> Optional[IndexFutureOption]:
+        """
+        Fetch an Index Future Option by strike price and index symbol.
+        
+        Args:
+            strike_price: The strike price
+            index_symbol: The underlying index symbol
+            
+        Returns:
+            IndexFutureOption entity or None if not found
+        """
+        try:
+            option = (
+                self.session.query(self.model_class)
+                .filter(
+                    self.model_class.strike_price == strike_price,
+                    self.model_class.index_symbol == index_symbol
+                )
+                .first()
+            )
+            return self.mapper.to_domain(option) if option else None
+        except Exception as e:
+            logger.error(f"Error retrieving index future option by strike {strike_price} and index {index_symbol}: {e}")
+            return None
+
+    def add(self, domain_option: IndexFutureOption) -> IndexFutureOption:
+        """Add a new Index Future Option record to the database."""
+        try:
+            new_option = self.mapper.to_orm(domain_option)
+            self.session.add(new_option)
+            self.session.commit()
+            return self.mapper.to_domain(new_option)
+        except Exception as e:
+            self.session.rollback()
+            logger.error(f"Error adding index future option: {e}")
+            return None
+
+    def get_by_symbol(self, symbol: str) -> Optional[IndexFutureOption]:
+        """Fetch an Index Future Option by its symbol."""
+        try:
+            option = (
+                self.session.query(self.model_class)
+                .filter(self.model_class.symbol == symbol)
+                .first()
+            )
+            return self.mapper.to_domain(option) if option else None
+        except Exception as e:
+            logger.error(f"Error retrieving index future option by symbol {symbol}: {e}")
+            return None

--- a/src/infrastructure/repositories/mappers/factor/index_future_option_delta_factor_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/index_future_option_delta_factor_mapper.py
@@ -1,0 +1,58 @@
+"""
+Mapper for IndexFutureOptionDeltaFactor domain entity and ORM model conversion.
+"""
+
+from typing import Optional
+
+from src.infrastructure.models.factor.factor import IndexFutureOptionDeltaFactorModel
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.index_future_option_delta_factor import IndexFutureOptionDeltaFactor
+from .base_factor_mapper import BaseFactorMapper
+
+
+class IndexFutureOptionDeltaFactorMapper(BaseFactorMapper):
+    """Mapper for IndexFutureOptionDeltaFactor domain entity and ORM model conversion."""
+    
+    @property
+    def discriminator(self):
+        return 'index_future_option_delta_factor'
+    
+    @property
+    def model_class(self):
+        return IndexFutureOptionDeltaFactorModel
+    
+    def get_factor_model(self):
+        return IndexFutureOptionDeltaFactorModel
+    
+    def get_factor_entity(self):
+        return IndexFutureOptionDeltaFactor
+    
+    @classmethod
+    def to_domain(cls, orm_model: Optional[IndexFutureOptionDeltaFactorModel]) -> Optional[IndexFutureOptionDeltaFactor]:
+        """Convert ORM model to IndexFutureOptionDeltaFactor domain entity."""
+        if not orm_model:
+            return None
+        
+        return IndexFutureOptionDeltaFactor(
+            name=orm_model.name,
+            group=orm_model.group,
+            subgroup=orm_model.subgroup,
+            data_type=orm_model.data_type,
+            source=orm_model.source,
+            definition=orm_model.definition,
+            factor_id=orm_model.id,
+            strike_price=getattr(orm_model, 'strike_price', None),
+            multiplier=getattr(orm_model, 'multiplier', None),
+            index_symbol=getattr(orm_model, 'index_symbol', None)
+        )
+    
+    @classmethod
+    def to_orm(cls, domain_entity: IndexFutureOptionDeltaFactor):
+        """Convert IndexFutureOptionDeltaFactor domain entity to ORM model."""
+        return IndexFutureOptionDeltaFactorModel(
+            name=domain_entity.name,
+            group=domain_entity.group,
+            subgroup=domain_entity.subgroup,
+            data_type=domain_entity.data_type,
+            source=domain_entity.source,
+            definition=domain_entity.definition
+        )

--- a/src/infrastructure/repositories/mappers/factor/index_future_option_factor_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/index_future_option_factor_mapper.py
@@ -1,0 +1,58 @@
+"""
+Mapper for IndexFutureOptionFactor domain entity and ORM model conversion.
+"""
+
+from typing import Optional
+
+from src.infrastructure.models.factor.factor import IndexFutureOptionFactorModel
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.index_future_option_factor import IndexFutureOptionFactor
+from .base_factor_mapper import BaseFactorMapper
+
+
+class IndexFutureOptionFactorMapper(BaseFactorMapper):
+    """Mapper for IndexFutureOptionFactor domain entity and ORM model conversion."""
+    
+    @property
+    def discriminator(self):
+        return 'index_future_option_factor'
+    
+    @property
+    def model_class(self):
+        return IndexFutureOptionFactorModel
+    
+    def get_factor_model(self):
+        return IndexFutureOptionFactorModel
+    
+    def get_factor_entity(self):
+        return IndexFutureOptionFactor
+    
+    @classmethod
+    def to_domain(cls, orm_model: Optional[IndexFutureOptionFactorModel]) -> Optional[IndexFutureOptionFactor]:
+        """Convert ORM model to IndexFutureOptionFactor domain entity."""
+        if not orm_model:
+            return None
+        
+        return IndexFutureOptionFactor(
+            name=orm_model.name,
+            group=orm_model.group,
+            subgroup=orm_model.subgroup,
+            data_type=orm_model.data_type,
+            source=orm_model.source,
+            definition=orm_model.definition,
+            factor_id=orm_model.id,
+            strike_price=getattr(orm_model, 'strike_price', None),
+            multiplier=getattr(orm_model, 'multiplier', None),
+            index_symbol=getattr(orm_model, 'index_symbol', None)
+        )
+    
+    @classmethod
+    def to_orm(cls, domain_entity: IndexFutureOptionFactor):
+        """Convert IndexFutureOptionFactor domain entity to ORM model."""
+        return IndexFutureOptionFactorModel(
+            name=domain_entity.name,
+            group=domain_entity.group,
+            subgroup=domain_entity.subgroup,
+            data_type=domain_entity.data_type,
+            source=domain_entity.source,
+            definition=domain_entity.definition
+        )

--- a/src/infrastructure/repositories/mappers/factor/index_future_option_price_factor_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/index_future_option_price_factor_mapper.py
@@ -1,0 +1,58 @@
+"""
+Mapper for IndexFutureOptionPriceFactor domain entity and ORM model conversion.
+"""
+
+from typing import Optional
+
+from src.infrastructure.models.factor.factor import IndexFutureOptionPriceFactorModel
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.index_future_option_price_factor import IndexFutureOptionPriceFactor
+from .base_factor_mapper import BaseFactorMapper
+
+
+class IndexFutureOptionPriceFactorMapper(BaseFactorMapper):
+    """Mapper for IndexFutureOptionPriceFactor domain entity and ORM model conversion."""
+    
+    @property
+    def discriminator(self):
+        return 'index_future_option_price_factor'
+    
+    @property
+    def model_class(self):
+        return IndexFutureOptionPriceFactorModel
+    
+    def get_factor_model(self):
+        return IndexFutureOptionPriceFactorModel
+    
+    def get_factor_entity(self):
+        return IndexFutureOptionPriceFactor
+    
+    @classmethod
+    def to_domain(cls, orm_model: Optional[IndexFutureOptionPriceFactorModel]) -> Optional[IndexFutureOptionPriceFactor]:
+        """Convert ORM model to IndexFutureOptionPriceFactor domain entity."""
+        if not orm_model:
+            return None
+        
+        return IndexFutureOptionPriceFactor(
+            name=orm_model.name,
+            group=orm_model.group,
+            subgroup=orm_model.subgroup,
+            data_type=orm_model.data_type,
+            source=orm_model.source,
+            definition=orm_model.definition,
+            factor_id=orm_model.id,
+            strike_price=getattr(orm_model, 'strike_price', None),
+            multiplier=getattr(orm_model, 'multiplier', None),
+            index_symbol=getattr(orm_model, 'index_symbol', None)
+        )
+    
+    @classmethod
+    def to_orm(cls, domain_entity: IndexFutureOptionPriceFactor):
+        """Convert IndexFutureOptionPriceFactor domain entity to ORM model."""
+        return IndexFutureOptionPriceFactorModel(
+            name=domain_entity.name,
+            group=domain_entity.group,
+            subgroup=domain_entity.subgroup,
+            data_type=domain_entity.data_type,
+            source=domain_entity.source,
+            definition=domain_entity.definition
+        )

--- a/src/infrastructure/repositories/mappers/factor/index_future_option_price_return_factor_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/index_future_option_price_return_factor_mapper.py
@@ -1,0 +1,58 @@
+"""
+Mapper for IndexFutureOptionPriceReturnFactor domain entity and ORM model conversion.
+"""
+
+from typing import Optional
+
+from src.infrastructure.models.factor.factor import IndexFutureOptionPriceReturnFactorModel
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.index_future_option_price_return_factor import IndexFutureOptionPriceReturnFactor
+from .base_factor_mapper import BaseFactorMapper
+
+
+class IndexFutureOptionPriceReturnFactorMapper(BaseFactorMapper):
+    """Mapper for IndexFutureOptionPriceReturnFactor domain entity and ORM model conversion."""
+    
+    @property
+    def discriminator(self):
+        return 'index_future_option_price_return_factor'
+    
+    @property
+    def model_class(self):
+        return IndexFutureOptionPriceReturnFactorModel
+    
+    def get_factor_model(self):
+        return IndexFutureOptionPriceReturnFactorModel
+    
+    def get_factor_entity(self):
+        return IndexFutureOptionPriceReturnFactor
+    
+    @classmethod
+    def to_domain(cls, orm_model: Optional[IndexFutureOptionPriceReturnFactorModel]) -> Optional[IndexFutureOptionPriceReturnFactor]:
+        """Convert ORM model to IndexFutureOptionPriceReturnFactor domain entity."""
+        if not orm_model:
+            return None
+        
+        return IndexFutureOptionPriceReturnFactor(
+            name=orm_model.name,
+            group=orm_model.group,
+            subgroup=orm_model.subgroup,
+            data_type=orm_model.data_type,
+            source=orm_model.source,
+            definition=orm_model.definition,
+            factor_id=orm_model.id,
+            strike_price=getattr(orm_model, 'strike_price', None),
+            multiplier=getattr(orm_model, 'multiplier', None),
+            index_symbol=getattr(orm_model, 'index_symbol', None)
+        )
+    
+    @classmethod
+    def to_orm(cls, domain_entity: IndexFutureOptionPriceReturnFactor):
+        """Convert IndexFutureOptionPriceReturnFactor domain entity to ORM model."""
+        return IndexFutureOptionPriceReturnFactorModel(
+            name=domain_entity.name,
+            group=domain_entity.group,
+            subgroup=domain_entity.subgroup,
+            data_type=domain_entity.data_type,
+            source=domain_entity.source,
+            definition=domain_entity.definition
+        )

--- a/src/infrastructure/repositories/mappers/finance/financial_assets/index_future_option_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/financial_assets/index_future_option_mapper.py
@@ -1,0 +1,87 @@
+"""
+Mapper for IndexFutureOption domain entity and ORM model.
+Converts between domain entities and ORM models to avoid metaclass conflicts.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from src.domain.entities.finance.financial_assets.derivatives.option.index_future_option import IndexFutureOption as DomainIndexFutureOption
+from src.infrastructure.models.finance.financial_assets.derivative.option.index_future_option import IndexFutureOptionModel as ORMIndexFutureOption
+
+
+class IndexFutureOptionMapper:
+    """Mapper for IndexFutureOption domain entity and ORM model."""
+    
+    @property
+    def discriminator(self):
+        return 'index_future_option'
+    
+    @property
+    def entity_class(self):
+        return DomainIndexFutureOption
+    
+    @property
+    def model_class(self):
+        return ORMIndexFutureOption
+    
+    @staticmethod
+    def to_domain(orm_obj: ORMIndexFutureOption) -> Optional[DomainIndexFutureOption]:
+        """Convert ORM IndexFutureOption model to domain IndexFutureOption entity."""
+        if not orm_obj:
+            return None
+
+        # Create the domain entity 
+        domain_entity = DomainIndexFutureOption(
+            id=orm_obj.id,
+            name=orm_obj.name if hasattr(orm_obj, 'name') else None,
+            symbol=orm_obj.symbol,
+            option_type=orm_obj.option_type.value if hasattr(orm_obj, 'option_type') and orm_obj.option_type else None,
+            strike_price=float(orm_obj.strike_price) if orm_obj.strike_price is not None else None,
+            multiplier=float(orm_obj.multiplier) if orm_obj.multiplier is not None else 1.0,
+            index_symbol=orm_obj.index_symbol,
+            currency_id=orm_obj.currency_id if hasattr(orm_obj, 'currency_id') else None,
+            exchange_id=orm_obj.exchange_id if hasattr(orm_obj, 'exchange_id') else None,
+            underlying_asset_id=orm_obj.underlying_asset_id if hasattr(orm_obj, 'underlying_asset_id') else None,
+            expiration_date=orm_obj.expiration_date if hasattr(orm_obj, 'expiration_date') else None,
+        )
+
+        return domain_entity
+
+    @staticmethod
+    def to_orm(domain_obj: DomainIndexFutureOption) -> ORMIndexFutureOption:
+        """Convert domain IndexFutureOption entity to ORM model."""
+        
+        orm_obj = ORMIndexFutureOption()
+
+        # Basic identification
+        orm_obj.symbol = domain_obj.symbol
+        orm_obj.name = domain_obj.name
+        
+        # Option-specific fields
+        if hasattr(domain_obj, 'option_type') and domain_obj.option_type:
+            # Convert string to enum if needed
+            from src.infrastructure.models.finance.financial_assets.derivative.options import OptionType
+            if isinstance(domain_obj.option_type, str):
+                orm_obj.option_type = OptionType(domain_obj.option_type.lower())
+            else:
+                orm_obj.option_type = domain_obj.option_type
+        
+        # Index future option specific fields
+        orm_obj.strike_price = Decimal(str(domain_obj.strike_price)) if domain_obj.strike_price is not None else None
+        orm_obj.multiplier = Decimal(str(domain_obj.multiplier)) if domain_obj.multiplier is not None else Decimal('1.0')
+        orm_obj.index_symbol = domain_obj.index_symbol
+        
+        # Additional fields
+        orm_obj.currency_id = domain_obj.currency_id if hasattr(domain_obj, 'currency_id') else None
+        orm_obj.exchange_id = domain_obj.exchange_id if hasattr(domain_obj, 'exchange_id') else None
+        orm_obj.underlying_asset_id = domain_obj.underlying_asset_id if hasattr(domain_obj, 'underlying_asset_id') else None
+        orm_obj.expiration_date = domain_obj.expiration_date if hasattr(domain_obj, 'expiration_date') else None
+
+        return orm_obj
+
+    @staticmethod
+    def to_infrastructure(domain_obj: DomainIndexFutureOption) -> ORMIndexFutureOption:
+        """Legacy method name for backward compatibility."""
+        return IndexFutureOptionMapper.to_orm(domain_obj)


### PR DESCRIPTION
This PR implements the complete infrastructure layer for index future option domain entities following the existing index_future structure.

## Changes
- Added IndexFutureOptionModel ORM model with strike_price, multiplier, and index_symbol fields
- Added IndexFutureOptionFactorModel, IndexFutureOptionPriceFactorModel, IndexFutureOptionPriceReturnFactorModel, and IndexFutureOptionDeltaFactorModel to factor.py
- Created IndexFutureOptionRepository with specialized queries for index options
- Created factor repositories: IndexFutureOptionFactorRepository, IndexFutureOptionPriceFactorRepository, IndexFutureOptionPriceReturnFactorRepository, IndexFutureOptionDeltaFactorRepository
- Created mappers for all entities: IndexFutureOptionMapper and factor mappers
- All components follow existing DDD patterns and index_future structure
- Implements full infrastructure layer for index future option domain entities

Resolves #399

🤖 Generated with [Claude Code](https://claude.ai/code)