### PR TITLE
fix: Register FuturePriceReturnFactor repository mapping

### DIFF
--- a/src/infrastructure/repositories/local_repo/factor/factor_repository_registry.py
+++ b/src/infrastructure/repositories/local_repo/factor/factor_repository_registry.py
@@ -40,6 +40,7 @@ from src.domain.entities.factor.finance.financial_assets.bond_factor.bond_factor
 from src.domain.entities.factor.finance.financial_assets.derivatives.derivative_factor import DerivativeFactor
 from src.domain.entities.factor.finance.financial_assets.derivatives.option.option_factor import OptionFactor
 from src.domain.entities.factor.finance.financial_assets.derivatives.future.future_factor import FutureFactor
+from src.domain.entities.factor.finance.financial_assets.derivatives.future.future_price_return_factor import FuturePriceReturnFactor
 
 from .base_factor_repository import BaseFactorRepository
 
@@ -71,6 +72,7 @@ FACTOR_REPOSITORY_MAPPING: Dict[Type, Type[BaseFactorRepository]] = {
     DerivativeFactor: DerivativeFactorRepository,
     OptionFactor: OptionsFactorRepository,
     FutureFactor: FuturesFactorRepository,
+    FuturePriceReturnFactor: FuturesFactorRepository,
 }
 
 


### PR DESCRIPTION
Fixes #406

**Problem:**
The system was failing to create entities for `FuturePriceReturnFactor` with the error: "No repository registered for entity class: FuturePriceReturnFactor"

**Solution:**
- Added import for FuturePriceReturnFactor entity
- Added mapping to FuturesFactorRepository in FACTOR_REPOSITORY_MAPPING
- Now properly handles symbols like return_daily, return_weekly, return_monthly

**Files Changed:**
- `src/infrastructure/repositories/local_repo/factor/factor_repository_registry.py`

Generated with [Claude Code](https://claude.ai/code)