### PR TITLE
feat: Add dedicated FuturePriceReturnFactorRepository following IndexPriceReturnFactor pattern

### DIFF
--- a/src/infrastructure/models/factor/factor.py
+++ b/src/infrastructure/models/factor/factor.py
@@ -58,6 +58,12 @@ class IndexPriceReturnFactorModel(FactorModel):
     }
 
 
+class FuturePriceReturnFactorModel(FactorModel):
+    __mapper_args__ = {
+        "polymorphic_identity": "future_price_return_factor"
+    }
+
+
 # Index Future Option Factor Models
 class IndexFutureOptionFactorModel(FactorModel):
     __mapper_args__ = {

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/future_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/future_price_return_factor_repository.py
@@ -1,0 +1,98 @@
+"""
+Repository class for FuturePriceReturnFactor entities.
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from src.infrastructure.repositories.mappers.factor.future_price_return_factor_mapper import FuturePriceReturnFactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class FuturePriceReturnFactorRepository(BaseFactorRepository):
+    """Repository for FuturePriceReturnFactor entities with CRUD operations."""
+    
+    def __init__(self, session: Session, factory=None):
+        super().__init__(session)
+        self.factory = factory
+        self.mapper = FuturePriceReturnFactorMapper()
+        self.mapper_value = FactorValueMapper()
+
+    @property
+    def entity_class(self):
+        return self.get_factor_entity()
+    @property
+    def model_class(self):
+        return self.mapper.model_class
+    def get_by_id(self, id: int):
+        entity = self._to_entity(self.session
+            .query(self.model_class)
+            .filter(self.model_class.id == id)
+            .one_or_none())
+        return entity
+    def get_factor_model(self):
+        return self.mapper.get_factor_model()
+    
+    def get_factor_entity(self):
+        return self.mapper.get_factor_entity()
+
+    def get_factor_value_model(self):
+        return self.mapper_value.get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return self.mapper_value.get_factor_value_entity()
+
+    def _to_entity(self, infra_obj):
+        """Convert ORM model to domain entity."""
+        return self.mapper.to_domain(infra_obj)
+    
+    def _to_model(self, entity):
+        """Convert domain entity to ORM model."""
+        return self.mapper.to_orm(entity)
+
+    def get_or_create(self, primary_key: str, **kwargs):
+        """
+        Get or create a future price return factor with dependency resolution.
+        
+        Args:
+            primary_key: Factor name identifier
+            **kwargs: Additional parameters for factor creation
+            
+        Returns:
+            FuturePriceReturnFactor entity
+        """
+        # Try to get existing entity first
+        existing_entity = self.get_by_name(primary_key)
+        
+        if existing_entity:
+            return existing_entity
+        
+        # Create new entity with default values
+        new_entity = self.get_factor_entity()(
+            name=primary_key,
+            group=kwargs.get('group', 'financial_assets'),
+            subgroup=kwargs.get('subgroup', 'derivatives'),
+            frequency=kwargs.get('frequency', 'daily'),
+            data_type=kwargs.get('data_type', 'float'),
+            source=kwargs.get('source', 'calculated'),
+            definition=kwargs.get('definition', 'Future price return factor')
+        )
+        
+        # Save to database
+        model = self._to_model(new_entity)
+        self.session.add(model)
+        self.session.flush()  # Flush to get the ID
+        
+        # Return entity with ID
+        new_entity.factor_id = model.id
+        return new_entity
+    
+    def get_by_name(self, name: str):
+        """Get factor by name."""
+        model = self.session.query(self.model_class).filter(
+            self.model_class.name == name
+        ).one_or_none()
+        
+        if model:
+            return self._to_entity(model)
+        return None

--- a/src/infrastructure/repositories/mappers/factor/future_price_return_factor_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/future_price_return_factor_mapper.py
@@ -1,0 +1,55 @@
+"""
+Mapper for FuturePriceReturnFactor domain entity and ORM model conversion.
+"""
+
+from typing import Optional
+
+from src.infrastructure.models.factor.factor import FuturePriceReturnFactorModel
+from src.domain.entities.factor.finance.financial_assets.derivatives.future.future_price_return_factor import FuturePriceReturnFactor
+from .base_factor_mapper import BaseFactorMapper
+
+
+class FuturePriceReturnFactorMapper(BaseFactorMapper):
+    """Mapper for FuturePriceReturnFactor domain entity and ORM model conversion."""
+    
+    @property
+    def discriminator(self):
+        return 'future'
+    @property
+    def model_class(self):
+        return FuturePriceReturnFactorModel
+    
+    def get_factor_model(self):
+        return FuturePriceReturnFactorModel
+    
+    def get_factor_entity(self):
+        return FuturePriceReturnFactor
+    
+    def to_domain(self, orm_model: Optional[FuturePriceReturnFactorModel]) -> Optional[FuturePriceReturnFactor]:
+        """Convert ORM model to FuturePriceReturnFactor domain entity."""
+        if not orm_model:
+            return None
+        
+        return FuturePriceReturnFactor(
+            factor_id=orm_model.id,
+            name=orm_model.name,
+            group=orm_model.group,
+            subgroup=orm_model.subgroup,
+            frequency=orm_model.frequency,
+            data_type=orm_model.data_type,
+            source=orm_model.source,
+            definition=orm_model.definition
+        )
+    
+    def to_orm(self, domain_entity: FuturePriceReturnFactor) -> FuturePriceReturnFactorModel:
+        """Convert FuturePriceReturnFactor domain entity to ORM model."""
+        return FuturePriceReturnFactorModel(
+            id=domain_entity.factor_id,
+            name=domain_entity.name,
+            group=domain_entity.group,
+            subgroup=domain_entity.subgroup,
+            frequency=domain_entity.frequency,
+            data_type=domain_entity.data_type,
+            source=domain_entity.source,
+            definition=domain_entity.definition
+        )

--- a/src/infrastructure/repositories/repository_factory.py
+++ b/src/infrastructure/repositories/repository_factory.py
@@ -36,6 +36,7 @@ from src.infrastructure.repositories.local_repo.factor.continent_factor_reposito
 from src.infrastructure.repositories.local_repo.factor.country_factor_repository import CountryFactorRepository
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.index_factor_repository import IndexFactorRepository
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.index_price_return_factor_repository import IndexPriceReturnFactorRepository
+from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.future_price_return_factor_repository import FuturePriceReturnFactorRepository
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.currency_factor_repository import CurrencyFactorRepository
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.equity_factor_repository import EquityFactorRepository
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.bond_factor_repository import BondFactorRepository
@@ -142,6 +143,7 @@ class RepositoryFactory:
                 'country_factor': CountryFactorRepository(self.session, factory=self),
                 'index_factor': IndexFactorRepository(self.session, factory=self),
                 'index_price_return_factor': IndexPriceReturnFactorRepository(self.session, factory=self),
+                'future_price_return_factor': FuturePriceReturnFactorRepository(self.session, factory=self),
                 'share_factor': ShareFactorRepository(self.session, factory=self),
                 'currency_factor': CurrencyFactorRepository(self.session, factory=self),
                 'equity_factor': EquityFactorRepository(self.session, factory=self),
@@ -846,6 +848,11 @@ class RepositoryFactory:
     def market_data_local_repo(self):
         """Get market_data repository for dependency injection."""
         return self._local_repositories.get('market_data')
+    
+    @property
+    def future_price_return_factor_local_repo(self):
+        """Get future_price_return_factor repository for dependency injection."""
+        return self._local_repositories.get('future_price_return_factor')
     
     # Additional IBKR repository properties
     @property


### PR DESCRIPTION
Fixes #406

**Problem:**
The system was failing to create entities for `FuturePriceReturnFactor` with the error: "No repository registered for entity class: FuturePriceReturnFactor"

**Root Cause:**
- `IndexPriceReturnFactor` works because it has its own dedicated `IndexPriceReturnFactorRepository` registered directly in `RepositoryFactory`
- `FuturePriceReturnFactor` was trying to use generic `FuturesFactorRepository` which only handles `FutureFactor` entities
- Repository factory lookup only checks exact matches via `repo.entity_class is entity_class`

**Solution:**
Followed the exact same pattern as `IndexPriceReturnFactor`:

1. **Added `FuturePriceReturnFactorModel`** with polymorphic identity 'future_price_return_factor'
2. **Created `FuturePriceReturnFactorMapper`** with proper domain/ORM conversion
3. **Created `FuturePriceReturnFactorRepository`** with same structure as IndexPriceReturnFactorRepository
4. **Registered repository in RepositoryFactory`** (import, registration, property method)

**Files Changed:**
- `src/infrastructure/models/factor/factor.py`
- `src/infrastructure/repositories/mappers/factor/future_price_return_factor_mapper.py` (new)
- `src/infrastructure/repositories/local_repo/factor/finance/financial_assets/future_price_return_factor_repository.py` (new)
- `src/infrastructure/repositories/repository_factory.py`

Generated with [Claude Code](https://claude.ai/code)