### PR TITLE
feat: update factor dependency configs with lag parameters

### DIFF
--- a/src/application/services/data/entities/factor/factor_library/finance/financial_assets/derivatives/future/future_index_library.py
+++ b/src/application/services/data/entities/factor/factor_library/finance/financial_assets/derivatives/future/future_index_library.py
@@ -96,7 +96,7 @@ FUTURE_INDEX_LIBRARY: Dict[str, Dict] = {
         "data_type": "numeric",
         "description": "Daily price return",
         "dependencies": {
-            "close": {
+            "start_price": {
                 "class": IndexFutureFactor,
                 "name": "close",
                 "group": "price",
@@ -104,8 +104,18 @@ FUTURE_INDEX_LIBRARY: Dict[str, Dict] = {
                 "data_type": "numeric",
                 "description": "Daily close price",
                 "dependencies": [],
-                "parameters": {}
+                "parameters": {"lag": timedelta(days=2, hours=0, minutes=0)}
             },
+            "end_price": {
+                "class": IndexFutureFactor,
+                "name": "close",
+                "group": "price",
+                "subgroup": "daily",
+                "data_type": "numeric",
+                "description": "Daily close price",
+                "dependencies": [],
+                "parameters": {"lag": timedelta(days=1, hours=0, minutes=0)}
+            }
         },
         "parameters": {"period": "1D"}
     },
@@ -119,7 +129,7 @@ FUTURE_INDEX_LIBRARY: Dict[str, Dict] = {
         "data_type": "numeric",
         "description": "Weekly price return",
         "dependencies": {
-            "close": {
+            "start_price": {
                 "class": IndexFutureFactor,
                 "name": "close",
                 "group": "price",
@@ -127,8 +137,18 @@ FUTURE_INDEX_LIBRARY: Dict[str, Dict] = {
                 "data_type": "numeric",
                 "description": "Weekly close price",
                 "dependencies": [],
-                "parameters": {}
+                "parameters": {"lag": timedelta(days=14, hours=0, minutes=0)}
             },
+            "end_price": {
+                "class": IndexFutureFactor,
+                "name": "close",
+                "group": "price",
+                "subgroup": "weekly",
+                "data_type": "numeric",
+                "description": "Weekly close price",
+                "dependencies": [],
+                "parameters": {"lag": timedelta(days=7, hours=0, minutes=0)}
+            }
         },
         "parameters": {"period": "1W"}
     },
@@ -142,7 +162,7 @@ FUTURE_INDEX_LIBRARY: Dict[str, Dict] = {
         "data_type": "numeric",
         "description": "Monthly price return",
         "dependencies": {
-            "close": {
+            "start_price": {
                 "class": IndexFutureFactor,
                 "name": "close",
                 "group": "price",
@@ -150,8 +170,18 @@ FUTURE_INDEX_LIBRARY: Dict[str, Dict] = {
                 "data_type": "numeric",
                 "description": "Monthly close price",
                 "dependencies": [],
-                "parameters": {}
+                "parameters": {"lag": timedelta(days=60, hours=0, minutes=0)}
             },
+            "end_price": {
+                "class": IndexFutureFactor,
+                "name": "close",
+                "group": "price",
+                "subgroup": "monthly",
+                "data_type": "numeric",
+                "description": "Monthly close price",
+                "dependencies": [],
+                "parameters": {"lag": timedelta(days=30, hours=0, minutes=0)}
+            }
         },
         "parameters": {"period": "1M"}
     },

--- a/src/application/services/data/entities/factor/factor_library/finance/financial_assets/index_library.py
+++ b/src/application/services/data/entities/factor/factor_library/finance/financial_assets/index_library.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Dict, List
 
 from src.domain.entities.factor.finance.financial_assets.index.index_factor import IndexFactor
@@ -78,7 +79,7 @@ INDEX_LIBRARY: Dict[str, Dict] = {
         "data_type": "numeric",
         "description": "Minute-level open price return",
         "dependencies": {
-            "open": {
+            "start_price": {
                 "class": IndexFactor,
                 "name": "open",
                 "group": "price",
@@ -86,7 +87,17 @@ INDEX_LIBRARY: Dict[str, Dict] = {
                 "data_type": "numeric",
                 "description": "Minute-level open price",
                 "dependencies": {},
-                "parameters": {}
+                "parameters": {"lag": timedelta(days=1, hours=0, minutes=0)}
+            },
+            "end_price": {
+                "class": IndexFactor,
+                "name": "open",
+                "group": "price",
+                "subgroup": "minutes",
+                "data_type": "numeric",
+                "description": "Minute-level open price",
+                "dependencies": {},
+                "parameters": {"lag": timedelta(days=0, hours=0, minutes=1)}
             }
         },
         "parameters": {}
@@ -104,7 +115,7 @@ INDEX_LIBRARY: Dict[str, Dict] = {
         "data_type": "numeric",
         "description": "Daily price return",
         "dependencies": {
-            "close": {
+            "start_price": {
                 "class": IndexFactor,
                 "name": "close",
                 "group": "price",
@@ -112,7 +123,17 @@ INDEX_LIBRARY: Dict[str, Dict] = {
                 "data_type": "numeric",
                 "description": "Daily close price",
                 "dependencies": {},
-                "parameters": {}
+                "parameters": {"lag": timedelta(days=2, hours=0, minutes=0)}
+            },
+            "end_price": {
+                "class": IndexFactor,
+                "name": "close",
+                "group": "price",
+                "subgroup": "daily",
+                "data_type": "numeric",
+                "description": "Daily close price",
+                "dependencies": {},
+                "parameters": {"lag": timedelta(days=1, hours=0, minutes=0)}
             }
         },
         "parameters": {"period": "1D"}
@@ -130,7 +151,7 @@ INDEX_LIBRARY: Dict[str, Dict] = {
         "data_type": "numeric",
         "description": "Weekly price return",
         "dependencies": {
-            "close": {
+            "start_price": {
                 "class": IndexFactor,
                 "name": "close",
                 "group": "price",
@@ -138,7 +159,17 @@ INDEX_LIBRARY: Dict[str, Dict] = {
                 "data_type": "numeric",
                 "description": "Weekly close price",
                 "dependencies": {},
-                "parameters": {}
+                "parameters": {"lag": timedelta(days=14, hours=0, minutes=0)}
+            },
+            "end_price": {
+                "class": IndexFactor,
+                "name": "close",
+                "group": "price",
+                "subgroup": "weekly",
+                "data_type": "numeric",
+                "description": "Weekly close price",
+                "dependencies": {},
+                "parameters": {"lag": timedelta(days=7, hours=0, minutes=0)}
             }
         },
         "parameters": {"period": "1W"}
@@ -156,7 +187,7 @@ INDEX_LIBRARY: Dict[str, Dict] = {
         "data_type": "numeric",
         "description": "Monthly price return",
         "dependencies": {
-            "close": {
+            "start_price": {
                 "class": IndexFactor,
                 "name": "close",
                 "group": "price",
@@ -164,7 +195,17 @@ INDEX_LIBRARY: Dict[str, Dict] = {
                 "data_type": "numeric",
                 "description": "Monthly close price",
                 "dependencies": {},
-                "parameters": {}
+                "parameters": {"lag": timedelta(days=60, hours=0, minutes=0)}
+            },
+            "end_price": {
+                "class": IndexFactor,
+                "name": "close",
+                "group": "price",
+                "subgroup": "monthly",
+                "data_type": "numeric",
+                "description": "Monthly close price",
+                "dependencies": {},
+                "parameters": {"lag": timedelta(days=30, hours=0, minutes=0)}
             }
         },
         "parameters": {"period": "1M"}


### PR DESCRIPTION
Updated all factor dependency configurations in FACTOR_LIBRARY to include lag parameters in the specified format:

- Updated INDEX_LIBRARY return factors with start_price/end_price structure
- Added lag parameters using timedelta for all return factors
- Extended FUTURE_INDEX_LIBRARY return factors with consistent lag structure
- Implemented progressive lag strategy (minutes->daily->weekly->monthly)

All return factors now follow the start_price/end_price dependency pattern with configurable lag parameters, enabling time-based factor calculations across different timeframes.

Closes #414

🤖 Generated with [Claude Code](https://claude.ai/code)