### PR TITLE
feat: integrate dependency population into IndexPriceReturnFactorRepository

### DIFF
--- a/src/infrastructure/repositories/local_repo/factor/factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/factor_repository.py
@@ -11,6 +11,7 @@ from src.infrastructure.repositories.mappers.factor.factor_mapper import FactorM
 from src.domain.ports.factor.factor_port import FactorPort
 from src.domain.entities.factor.factor_dependency import FactorDependency
 from src.application.services.data.entities.factor.factor_library.factor_definition_config import get_factor_config, FACTOR_LIBRARY
+from src.infrastructure.models.factor.factor_dependency import FactorDependencyModel
 
 
 class FactorRepository(BaseFactorRepository, FactorPort):
@@ -241,4 +242,119 @@ class FactorRepository(BaseFactorRepository, FactorPort):
             return None
             
         return self._create_or_get_with_config(name, factor_config)
+
+    def get_factor_by_name_and_group(self, name: str, group: str) -> Optional[Factor]:
+        """
+        Retrieve a factor by both name and group parameters.
+        
+        Args:
+            name: Factor name to search for
+            group: Factor group to search for
+            
+        Returns:
+            Factor entity or None if not found
+        """
+        try:
+            model = self.session.query(FactorModel).filter(
+                FactorModel.name == name,
+                FactorModel.group == group
+            ).first()
+            return self._to_entity(model)
+        except Exception as e:
+            print(f"Error retrieving factor by name and group: {e}")
+            return None
+
+    def _populate_single_factor_dependencies(self, factor_name: str) -> int:
+        """
+        Populate dependencies for a single factor from FACTOR_LIBRARY configuration.
+        
+        Args:
+            factor_name: Name of the factor to populate dependencies for
+            
+        Returns:
+            Number of dependency relationships created
+        """
+        count = 0
+        factor_config = self._get_factor_config_from_library(factor_name)
+        
+        if not factor_config:
+            return count
+            
+        # Get or create the main factor
+        main_factor = self.get_factor_by_name_and_group(factor_name, factor_config.get("group", "basic"))
+        if not main_factor:
+            main_factor = self._create_or_get_with_config(factor_name, factor_config)
+            
+        if not main_factor:
+            return count
+            
+        # Handle structured dependencies (dict format with parameter names)
+        dependencies = factor_config.get("dependencies", {})
+        
+        if isinstance(dependencies, dict):
+            for param_name, dep_config in dependencies.items():
+                if isinstance(dep_config, dict):
+                    dep_name = dep_config.get("name")
+                    dep_group = dep_config.get("group", "basic")
+                    
+                    # Get or create the dependency factor
+                    dep_factor = self.get_factor_by_name_and_group(dep_name, dep_group)
+                    if not dep_factor:
+                        dep_factor = self._create_or_get_with_config(dep_name, dep_config)
+                        
+                    if dep_factor:
+                        # Extract lag from parameters
+                        lag = None
+                        if "parameters" in dep_config and "lag" in dep_config["parameters"]:
+                            lag = dep_config["parameters"]["lag"]
+                            
+                        # Check if dependency relationship already exists
+                        existing_dep = self.session.query(FactorDependencyModel).filter(
+                            FactorDependencyModel.dependent_factor_id == main_factor.id,
+                            FactorDependencyModel.independent_factor_id == dep_factor.id
+                        ).first()
+                        
+                        if not existing_dep:
+                            # Create new dependency relationship
+                            dependency_model = FactorDependencyModel(
+                                dependent_factor_id=main_factor.id,
+                                independent_factor_id=dep_factor.id,
+                                lag=lag
+                            )
+                            self.session.add(dependency_model)
+                            count += 1
+                            
+        return count
+
+    def populate_dependencies_from_library(self, factor_name: str = None) -> int:
+        """
+        Populate factor dependencies from FACTOR_LIBRARY configuration to database.
+        
+        Args:
+            factor_name: Specific factor name to populate (None for all factors)
+            
+        Returns:
+            Total number of dependency relationships created
+        """
+        total_count = 0
+        
+        try:
+            if factor_name:
+                # Populate dependencies for a specific factor
+                total_count = self._populate_single_factor_dependencies(factor_name)
+            else:
+                # Populate dependencies for all factors in library
+                for library_name, library_content in FACTOR_LIBRARY.items():
+                    if isinstance(library_content, dict):
+                        for name, config in library_content.items():
+                            if isinstance(config, dict) and "dependencies" in config:
+                                total_count += self._populate_single_factor_dependencies(name)
+                                
+            self.session.commit()
+            
+        except Exception as e:
+            print(f"Error populating dependencies from library: {e}")
+            self.session.rollback()
+            
+        return total_count
 

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_price_return_factor_repository.py
@@ -4,6 +4,7 @@ Repository class for IndexPriceReturnFactor entities.
 
 from typing import Optional
 from sqlalchemy.orm import Session
+from src.domain.entities.factor.factor import Factor
 from src.domain.entities.factor.factor_dependency import FactorDependency
 from src.infrastructure.repositories.mappers.factor.index_price_return_factor_mapper import IndexPriceReturnFactorMapper
 from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
@@ -84,7 +85,20 @@ class IndexPriceReturnFactorRepository(BaseFactorRepository):
             orm_factor = self._to_model(domain_factor)
             
             self.session.add(orm_factor)
-            #create_or_get dependencies
+            self.session.commit()  # Commit factor first to get ID
+            
+            # Populate dependencies from FACTOR_LIBRARY using FactorRepository
+            if self.factory:
+                try:
+                    factor_repo = self.factory.get_local_repository(Factor)
+                    if factor_repo and hasattr(factor_repo, 'populate_dependencies_from_library'):
+                        dependencies_count = factor_repo.populate_dependencies_from_library(primary_key)
+                        if dependencies_count > 0:
+                            print(f"Populated {dependencies_count} dependencies for factor: {primary_key}")
+                except Exception as e:
+                    print(f"Warning: Could not populate dependencies from library for {primary_key}: {e}")
+            
+            #create_or_get dependencies (legacy support)
             if kwargs.get('dependencies'):
                 dependencies = kwargs.get('dependencies')
                 for dependency in dependencies.items():
@@ -107,7 +121,6 @@ class IndexPriceReturnFactorRepository(BaseFactorRepository):
                     repo_factor_dependency._create_or_get(independent_factor = dependency_entity ,dependent_factor = self._to_entity(orm_factor), lag=lag)
  
             
-            self.session.commit()
             if orm_factor:
                 return self._to_entity(orm_factor)
             

--- a/test_dependency_integration.py
+++ b/test_dependency_integration.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Test script to validate IndexPriceReturnFactorRepository dependency integration.
+"""
+
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), 'src')))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from src.infrastructure.repositories.repository_factory import RepositoryFactory
+from src.domain.entities.factor.finance.financial_assets.index.index_price_return_factor import IndexPriceReturnFactor
+
+def test_dependency_integration():
+    """Test that IndexPriceReturnFactorRepository properly populates dependencies."""
+    
+    # Create database engine (using SQLite for testing)
+    engine = create_engine('sqlite:///:memory:', echo=True)
+    
+    # Create session
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    
+    # Create all tables
+    from src.infrastructure.models import ModelBase
+    ModelBase.metadata.create_all(engine)
+    
+    # Create repository factory
+    factory = RepositoryFactory(session=session)
+    
+    try:
+        # Get the IndexPriceReturnFactorRepository
+        index_price_return_factor_repo = factory.get_local_repository(IndexPriceReturnFactor)
+        
+        if not index_price_return_factor_repo:
+            print("ERROR: Could not get IndexPriceReturnFactorRepository from factory")
+            return False
+            
+        print(f"✅ Got IndexPriceReturnFactorRepository: {type(index_price_return_factor_repo).__name__}")
+        
+        # Test creating a return_daily factor
+        print("\n🔧 Testing return_daily factor creation with dependency population...")
+        
+        factor = index_price_return_factor_repo._create_or_get(
+            entity_cls=IndexPriceReturnFactor,
+            primary_key="return_daily",
+            group="return",
+            subgroup="daily",
+            data_type="numeric",
+            source="calculated"
+        )
+        
+        if factor:
+            print(f"✅ Created factor: {factor.name} (ID: {factor.id})")
+            
+            # Check if dependencies were created
+            from src.infrastructure.models.factor.factor_dependency import FactorDependencyModel
+            dependencies = session.query(FactorDependencyModel).filter(
+                FactorDependencyModel.dependent_factor_id == factor.id
+            ).all()
+            
+            print(f"📊 Found {len(dependencies)} dependencies:")
+            for dep in dependencies:
+                print(f"  - Dependency: factor_id {dep.independent_factor_id}, lag: {dep.lag}")
+                
+            if len(dependencies) >= 2:
+                print("✅ SUCCESS: Factor dependencies were properly populated!")
+                return True
+            else:
+                print("⚠️ WARNING: Expected 2 dependencies (start_price, end_price), found {len(dependencies)}")
+                return False
+        else:
+            print("❌ ERROR: Failed to create return_daily factor")
+            return False
+            
+    except Exception as e:
+        print(f"❌ ERROR: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+    finally:
+        session.close()
+
+if __name__ == "__main__":
+    success = test_dependency_integration()
+    if success:
+        print("\n🎉 Test passed: Dependency integration working correctly!")
+    else:
+        print("\n💥 Test failed: Dependency integration needs fixing")
+    
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
Integrate dependency population methods into IndexPriceReturnFactorRepository to fix return_daily calculation issues:

- Add get_factor_by_name_and_group() method to FactorRepository
- Add _populate_single_factor_dependencies() method to FactorRepository
- Add populate_dependencies_from_library() method to FactorRepository
- Integrate dependency population into IndexPriceReturnFactorRepository._create_or_get()
- Use factory pattern to access FactorRepository for dependency population
- Handle structured dependencies with proper lag mapping from FACTOR_LIBRARY
- Add comprehensive test script for dependency integration validation

Addresses issue where return_daily factor only found 1 dependency instead of structured start_price/end_price dependencies from INDEX_LIBRARY configuration.

Generated with [Claude Code](https://claude.ai/code)