### PR TITLE
fix: resolve factor dependency population for return_daily

### DIFF
--- a/debug_factor_dependency_issue.py
+++ b/debug_factor_dependency_issue.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Debug Factor Dependency Issue
+Investigate why return_daily factor only has 1 dependency instead of 2 structured dependencies
+"""
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from src.infrastructure.models.factor.factor import FactorModel
+from src.infrastructure.models.factor.factor_dependency import FactorDependencyModel
+from src.application.services.data.entities.factor.factor_library.factor_definition_config import FACTOR_LIBRARY
+from src.application.services.data.entities.factor.factor_library.finance.financial_assets.index_library import INDEX_LIBRARY
+
+def debug_factor_dependencies():
+    """Debug current state of factor dependencies"""
+    print("=== DEBUGGING FACTOR DEPENDENCY ISSUE ===\n")
+    
+    # 1. Check INDEX_LIBRARY configuration for return_daily
+    print("1. INDEX_LIBRARY Configuration for return_daily:")
+    return_daily_config = INDEX_LIBRARY.get('return_daily')
+    if return_daily_config:
+        print(f"   Factor: {return_daily_config.get('name')}")
+        print(f"   Group: {return_daily_config.get('group')}")
+        print(f"   Subgroup: {return_daily_config.get('subgroup')}")
+        print(f"   Dependencies: {return_daily_config.get('dependencies')}")
+        
+        deps = return_daily_config.get('dependencies', {})
+        for param_name, dep_config in deps.items():
+            print(f"      {param_name}: {dep_config.get('name')} (lag: {dep_config.get('parameters', {}).get('lag')})")
+    else:
+        print("   return_daily NOT FOUND in INDEX_LIBRARY")
+    
+    print("\n2. FACTOR_LIBRARY Structure:")
+    for lib_name, lib_content in FACTOR_LIBRARY.items():
+        print(f"   {lib_name}: {type(lib_content)}")
+        if lib_name == "index_library" and hasattr(lib_content, '__len__'):
+            print(f"      Contains {len(lib_content)} factors")
+    
+    # 3. Check database schema
+    try:
+        engine = create_engine('sqlite:///base_infra.db')
+        with engine.connect() as conn:
+            print("\n3. Database Schema Check:")
+            
+            # Check factor_dependencies table structure
+            result = conn.execute(text("PRAGMA table_info(factor_dependencies)"))
+            columns = result.fetchall()
+            print("   factor_dependencies table columns:")
+            for col in columns:
+                print(f"      {col[1]} ({col[2]}) - nullable: {col[3] == 0}")
+            
+            # Check current dependencies for factor ID 14
+            print("\n4. Current Dependencies for Factor ID 14 (return_daily):")
+            result = conn.execute(text("""
+                SELECT 
+                    fd.id,
+                    fd.dependent_factor_id,
+                    fd.independent_factor_id,
+                    fd.lag,
+                    f1.name as dependent_name,
+                    f2.name as independent_name,
+                    f2.group as independent_group
+                FROM factor_dependencies fd
+                JOIN factors f1 ON fd.dependent_factor_id = f1.id
+                JOIN factors f2 ON fd.independent_factor_id = f2.id
+                WHERE fd.dependent_factor_id = 14
+            """))
+            deps = result.fetchall()
+            
+            if deps:
+                for dep in deps:
+                    print(f"   Dependency {dep[0]}: {dep[4]} -> {dep[5]} (group: {dep[6]}, lag: {dep[3]})")
+            else:
+                print("   No dependencies found for factor ID 14")
+            
+            # Check all factors with return group
+            print("\n5. All Factors in 'return' Group:")
+            result = conn.execute(text("""
+                SELECT id, name, subgroup, factor_type 
+                FROM factors 
+                WHERE [group] = 'return' 
+                ORDER BY id
+            """))
+            factors = result.fetchall()
+            for factor in factors:
+                print(f"   ID {factor[0]}: {factor[1]} ({factor[2]}) - {factor[3]}")
+                
+            # Check close price factors (potential dependencies)
+            print("\n6. Potential Dependency Factors (close, price group):")
+            result = conn.execute(text("""
+                SELECT id, name, [group], subgroup, factor_type 
+                FROM factors 
+                WHERE name = 'close' OR [group] = 'price'
+                ORDER BY id
+            """))
+            price_factors = result.fetchall()
+            for factor in price_factors:
+                print(f"   ID {factor[0]}: {factor[1]} ({factor[2]}.{factor[3]}) - {factor[4]}")
+                
+    except Exception as e:
+        print(f"Database error: {e}")
+
+if __name__ == "__main__":
+    debug_factor_dependencies()

--- a/populate_return_daily_fix.py
+++ b/populate_return_daily_fix.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Script to manually populate return_daily dependencies with proper lag values
+"""
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from datetime import timedelta
+from src.infrastructure.repositories.local_repo.factory import RepositoryFactory
+from src.domain.entities.factor.factor import Factor
+from src.infrastructure.models.factor.factor_dependency import FactorDependencyModel
+
+def populate_return_daily_dependencies():
+    """Manually populate return_daily dependencies with proper lag values"""
+    print("=== POPULATING RETURN_DAILY DEPENDENCIES ===\n")
+    
+    try:
+        # Create database session
+        engine = create_engine('sqlite:///base_infra.db')
+        Session = sessionmaker(bind=engine)
+        session = Session()
+        
+        # Create repository factory
+        factory = RepositoryFactory(session)
+        factor_repo = factory.get_local_repository(Factor)
+        
+        print("1. Populating dependencies for return_daily factor:")
+        count = factor_repo.populate_dependencies_from_library("return_daily")
+        
+        print(f"\n2. Total dependencies created: {count}")
+        
+        print("\n3. Verifying database state:")
+        # Query all dependencies with lag information
+        result = session.execute(text("""
+            SELECT 
+                fd.id,
+                fd.dependent_factor_id,
+                fd.independent_factor_id,
+                fd.lag,
+                f1.name as dependent_name,
+                f1.factor_type as dependent_type,
+                f2.name as independent_name,
+                f2.group as independent_group,
+                f2.subgroup as independent_subgroup
+            FROM factor_dependencies fd
+            JOIN factors f1 ON fd.dependent_factor_id = f1.id
+            JOIN factors f2 ON fd.independent_factor_id = f2.id
+            WHERE f1.name = 'return_daily' AND f1.factor_type = 'index_price_return_factor'
+            ORDER BY fd.id
+        """))
+        deps = result.fetchall()
+        
+        print(f"   Found {len(deps)} dependencies for return_daily:")
+        for dep in deps:
+            print(f"      ID {dep[0]}: {dep[4]} -> {dep[6]} ({dep[7]}.{dep[8]}) - lag: {dep[3]}")
+            
+        # Expected: 2 dependencies (start_price with 2-day lag, end_price with 1-day lag)
+        if len(deps) == 2:
+            print("\n✅ SUCCESS: 2 dependencies found as expected")
+            # Check if lags are properly set
+            lags_found = [dep[3] for dep in deps if dep[3] is not None]
+            print(f"   Lag values: {lags_found}")
+        elif len(deps) == 1:
+            print(f"\n❌ ISSUE: Only 1 dependency found (was {deps[0][6]})")
+        else:
+            print(f"\n❌ ISSUE: {len(deps)} dependencies found (expected 2)")
+        
+        print("\n4. All factor dependencies in database:")
+        result = session.execute(text("""
+            SELECT 
+                fd.dependent_factor_id,
+                f1.name as dependent_name,
+                COUNT(*) as dependency_count
+            FROM factor_dependencies fd
+            JOIN factors f1 ON fd.dependent_factor_id = f1.id
+            GROUP BY fd.dependent_factor_id, f1.name
+            ORDER BY fd.dependent_factor_id
+        """))
+        all_deps = result.fetchall()
+        
+        for dep in all_deps:
+            print(f"   Factor ID {dep[0]} ({dep[1]}): {dep[2]} dependencies")
+        
+        session.close()
+        print("\n=== DONE ===")
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    populate_return_daily_dependencies()

--- a/src/infrastructure/repositories/local_repo/factor/factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/factor_repository.py
@@ -55,20 +55,10 @@ class FactorRepository(BaseFactorRepository, FactorPort):
         """
         Find factor configuration from the factor library by name.
         Searches through all nested libraries (INDEX_LIBRARY, FUTURE_INDEX_LIBRARY, etc.)
-        """
-        # Check main FACTOR_LIBRARY first
-        config = get_factor_config(name)
-        if config:
-            return config
-            
-        # Search through nested libraries
+        """        
+        # Search through nested libraries directly
         for library_key, library_value in FACTOR_LIBRARY.items():
-            if isinstance(library_value, set) and len(library_value) == 1:
-                # Handle the current nested structure like {"future_index_library":{FUTURE_INDEX_LIBRARY}}
-                nested_lib = list(library_value)[0]
-                if isinstance(nested_lib, dict) and name in nested_lib:
-                    return nested_lib[name]
-            elif isinstance(library_value, dict) and name in library_value:
+            if isinstance(library_value, dict) and name in library_value:
                 return library_value[name]
                 
         return None
@@ -342,13 +332,17 @@ class FactorRepository(BaseFactorRepository, FactorPort):
             if factor_name:
                 # Populate dependencies for a specific factor
                 total_count = self._populate_single_factor_dependencies(factor_name)
+                print(f"Populated {total_count} dependencies for factor: {factor_name}")
             else:
                 # Populate dependencies for all factors in library
                 for library_name, library_content in FACTOR_LIBRARY.items():
                     if isinstance(library_content, dict):
                         for name, config in library_content.items():
                             if isinstance(config, dict) and "dependencies" in config:
-                                total_count += self._populate_single_factor_dependencies(name)
+                                count = self._populate_single_factor_dependencies(name)
+                                total_count += count
+                                if count > 0:
+                                    print(f"Populated {count} dependencies for factor: {name}")
                                 
             self.session.commit()
             

--- a/test_dependency_fix.py
+++ b/test_dependency_fix.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Test script to verify factor dependency population fix
+"""
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from src.infrastructure.repositories.local_repo.factory import RepositoryFactory
+from src.domain.entities.factor.factor import Factor
+from src.application.services.data.entities.factor.factor_library.finance.financial_assets.index_library import INDEX_LIBRARY
+
+def test_dependency_fix():
+    """Test the dependency population fix"""
+    print("=== TESTING DEPENDENCY POPULATION FIX ===\n")
+    
+    try:
+        # Create database session
+        engine = create_engine('sqlite:///base_infra.db')
+        Session = sessionmaker(bind=engine)
+        session = Session()
+        
+        # Create repository factory
+        factory = RepositoryFactory(session)
+        factor_repo = factory.get_local_repository(Factor)
+        
+        print("1. Testing _get_factor_config_from_library method:")
+        return_daily_config = factor_repo._get_factor_config_from_library("return_daily")
+        if return_daily_config:
+            print("   ✅ Found return_daily config in library")
+            print(f"   Group: {return_daily_config.get('group')}")
+            print(f"   Dependencies: {list(return_daily_config.get('dependencies', {}).keys())}")
+        else:
+            print("   ❌ return_daily config NOT FOUND")
+        
+        print("\n2. Testing _populate_single_factor_dependencies method:")
+        count = factor_repo._populate_single_factor_dependencies("return_daily")
+        print(f"   Created {count} dependency relationships for return_daily")
+        
+        if count > 0:
+            print("   ✅ Dependencies populated successfully")
+        else:
+            print("   ❌ No dependencies were populated")
+            
+        print("\n3. Checking database state after population:")
+        from sqlalchemy import text
+        
+        # Query dependencies for return_daily factor
+        result = session.execute(text("""
+            SELECT 
+                fd.id,
+                fd.dependent_factor_id,
+                fd.independent_factor_id,
+                fd.lag,
+                f1.name as dependent_name,
+                f2.name as independent_name,
+                f2.group as independent_group
+            FROM factor_dependencies fd
+            JOIN factors f1 ON fd.dependent_factor_id = f1.id
+            JOIN factors f2 ON fd.independent_factor_id = f2.id
+            WHERE f1.name = 'return_daily' AND f1.factor_type = 'index_price_return_factor'
+        """))
+        deps = result.fetchall()
+        
+        print(f"   Found {len(deps)} dependencies for return_daily:")
+        for dep in deps:
+            print(f"      {dep[4]} -> {dep[5]} (group: {dep[6]}, lag: {dep[3]})")
+            
+        if len(deps) == 2:
+            print("   ✅ EXPECTED: 2 dependencies found")
+        else:
+            print(f"   ❌ UNEXPECTED: {len(deps)} dependencies (expected 2)")
+        
+        session.close()
+        
+    except Exception as e:
+        print(f"Test failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    test_dependency_fix()


### PR DESCRIPTION
Fix factor dependency population system to create proper structured dependencies with lag values:

- Fix _get_factor_config_from_library() to properly search INDEX_LIBRARY
- Remove incorrect get_factor_config() call for nested library traversal
- Add debug logging to populate_dependencies_from_library() method
- Create comprehensive test and debug scripts for validation
- Fix return_daily factor to have 2 dependencies (start_price, end_price) with proper lag values

Addresses issue where return_daily factor only found 1 dependency instead of structured dependencies from INDEX_LIBRARY configuration.

Generated with [Claude Code](https://claude.ai/code)