### PR TITLE
fix: add frequency parameter to factor creation

### DIFF
--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/future_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/future_price_return_factor_repository.py
@@ -78,6 +78,7 @@ class FuturePriceReturnFactorRepository(BaseFactorRepository):
                 name=primary_key,
                 group=kwargs.get('group', 'return'),
                 subgroup=kwargs.get('subgroup', 'daily'),
+                frequency=kwargs.get('frequency', '1d'),
                 data_type=kwargs.get('data_type', 'numeric'),
                 source=kwargs.get('source', 'calculated'),
                 definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')
@@ -100,6 +101,7 @@ class FuturePriceReturnFactorRepository(BaseFactorRepository):
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),
+                            frequency=dependency_config.get("frequency", "1d"),
                             data_type=dependency_config.get("data_type"),
                             factor_type=dependency_config.get("factor_type"),
                             source=dependency_config.get("source"),

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_factor_repository.py
@@ -74,6 +74,7 @@ class IndexFactorRepository(BaseFactorRepository):
             domain_factor = self.get_factor_entity()(name=primary_key,
                 group=kwargs.get('group', 'index'),
                 subgroup=kwargs.get('subgroup', 'daily'),
+                frequency=kwargs.get('frequency', '1d'),
                 data_type=kwargs.get('data_type', 'numeric'),
                 source=kwargs.get('source', 'market_data'),
                 definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_factor_repository.py
@@ -72,6 +72,7 @@ class IndexFutureFactorRepository(BaseFactorRepository):
             domain_factor = self.get_factor_entity()(name=primary_key,
                 group=kwargs.get('group', 'index_future'),
                 subgroup=kwargs.get('subgroup', 'daily'),
+                frequency=kwargs.get('frequency', '1d'),
                 data_type=kwargs.get('data_type', 'numeric'),
                 source=kwargs.get('source', 'market_data'),
                 definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_price_return_factor_repository.py
@@ -79,6 +79,7 @@ class IndexFuturePriceReturnFactorRepository(BaseFactorRepository):
                 name=primary_key,
                 group=kwargs.get('group', 'return'),
                 subgroup=kwargs.get('subgroup', 'daily'),
+                frequency=kwargs.get('frequency', '1d'),
                 data_type=kwargs.get('data_type', 'numeric'),
                 source=kwargs.get('source', 'calculated'),
                 definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')
@@ -101,6 +102,7 @@ class IndexFuturePriceReturnFactorRepository(BaseFactorRepository):
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),
+                            frequency=dependency_config.get("frequency", "1d"),
                             data_type=dependency_config.get("data_type"),
                             factor_type=dependency_config.get("factor_type"),
                             source=dependency_config.get("source"),

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_price_return_factor_repository.py
@@ -79,6 +79,7 @@ class IndexPriceReturnFactorRepository(BaseFactorRepository):
                 name=primary_key,
                 group=kwargs.get('group', 'return'),
                 subgroup=kwargs.get('subgroup', 'daily'),
+                frequency=kwargs.get('frequency', '1d'),
                 data_type=kwargs.get('data_type', 'numeric'),
                 source=kwargs.get('source', 'calculated'),
                 definition=kwargs.get('definition', f'{self.mapper.discriminator} factor: {primary_key}')
@@ -111,6 +112,7 @@ class IndexPriceReturnFactorRepository(BaseFactorRepository):
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),
+                            frequency=dependency_config.get("frequency", "1d"),
                             data_type=dependency_config.get("data_type"),
                             factor_type=dependency_config.get("factor_type"),
                             source=dependency_config.get("source"),


### PR DESCRIPTION
Fix factor frequency attribution issue in repository _create_or_get methods

- Add frequency=kwargs.get('frequency', '1d') to factor domain entity constructors
- Fix IndexFutureFactorRepository, IndexFuturePriceReturnFactorRepository, IndexFactorRepository, IndexPriceReturnFactorRepository, and FuturePriceReturnFactorRepository
- Ensure factor frequency field is properly attributed as specified in FactorModel
- Default to '1d' (daily) frequency when not specified
- Also fix dependency creation calls to include frequency parameter

Resolves issue #426

🤖 Generated with [Claude Code](https://claude.ai/code)