### PR TITLE
fix: add missing entity_cls parameter to factor repository methods

### DIFF
--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_factor_repository.py
@@ -53,11 +53,12 @@ class IndexFactorRepository(BaseFactorRepository):
         """Convert domain entity to ORM model."""
         return self.mapper.to_orm(entity)
 
-    def _create_or_get(self, primary_key: str, **kwargs):
+    def _create_or_get(self, entity_cls, primary_key: str, **kwargs):
         """
         Get or create an index factor with dependency resolution.
         
         Args:
+            entity_cls: The entity class (not used but required for interface consistency)
             primary_key: Factor name identifier
             **kwargs: Additional parameters for factor creation
             

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_factor_repository.py
@@ -50,11 +50,12 @@ class IndexFutureFactorRepository(BaseFactorRepository):
         """Convert domain entity to ORM model."""
         return IndexFutureFactorMapper.to_orm(entity)
 
-    def _create_or_get(self, primary_key: str, **kwargs):
+    def _create_or_get(self, entity_cls, primary_key: str, **kwargs):
         """
         Get or create an index future factor with dependency resolution.
         
         Args:
+            entity_cls: The entity class (not used but required for interface consistency)
             primary_key: Factor name identifier
             **kwargs: Additional parameters for factor creation
             


### PR DESCRIPTION
Fix method signature errors in factor repositories

- Add missing entity_cls parameter to IndexFutureFactorRepository._create_or_get
- Add missing entity_cls parameter to IndexFactorRepository._create_or_get
- Update method docstrings to document the entity_cls parameter
- Ensures interface consistency with working repositories
- Resolves "takes 2 positional arguments but 3 were given" errors

Resolves issue #426

🤖 Generated with [Claude Code](https://claude.ai/code)