### PR TITLE
fix: add missing entity_cls parameter to dependency creation calls

### DIFF
--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/future_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/future_price_return_factor_repository.py
@@ -98,6 +98,7 @@ class FuturePriceReturnFactorRepository(BaseFactorRepository):
                     
                     dependency_config = dependency[1]
                     dependency_entity = repo._create_or_get(
+                            entity_class,
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_option_price_return_factor_repository.py
@@ -100,9 +100,11 @@ class IndexFutureOptionPriceReturnFactorRepository(BaseFactorRepository):
                     
                     dependency_config = dependency[1]
                     dependency_entity = repo._create_or_get(
+                            entity_class,
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),
+                            frequency=dependency_config.get("frequency", "1d"),
                             data_type=dependency_config.get("data_type"),
                             factor_type=dependency_config.get("factor_type"),
                             source=dependency_config.get("source"),

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_future_price_return_factor_repository.py
@@ -99,6 +99,7 @@ class IndexFuturePriceReturnFactorRepository(BaseFactorRepository):
                     
                     dependency_config = dependency[1]
                     dependency_entity = repo._create_or_get(
+                            entity_class,
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index_price_return_factor_repository.py
@@ -109,6 +109,7 @@ class IndexPriceReturnFactorRepository(BaseFactorRepository):
                     
                     dependency_config = dependency[1]
                     dependency_entity = repo._create_or_get(
+                            entity_class,
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/portfolio_company_share_option_delta_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/portfolio_company_share_option_delta_factor_repository.py
@@ -100,9 +100,11 @@ class PortfolioCompanyShareOptionDeltaFactorRepository(BaseFactorRepository):
                     
                     dependency_config = dependency[1]
                     dependency_entity = repo._create_or_get(
+                            entity_class,
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),
+                            frequency=dependency_config.get("frequency", "1d"),
                             data_type=dependency_config.get("data_type"),
                             factor_type=dependency_config.get("factor_type"),
                             source=dependency_config.get("source"),

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/portfolio_company_share_option_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/portfolio_company_share_option_price_return_factor_repository.py
@@ -100,9 +100,11 @@ class PortfolioCompanyShareOptionPriceReturnFactorRepository(BaseFactorRepositor
                     
                     dependency_config = dependency[1]
                     dependency_entity = repo._create_or_get(
+                            entity_class,
                             primary_key=dependency_config.get("name"),
                             group=dependency_config.get("group"),
                             subgroup=dependency_config.get("subgroup"),
+                            frequency=dependency_config.get("frequency", "1d"),
                             data_type=dependency_config.get("data_type"),
                             factor_type=dependency_config.get("factor_type"),
                             source=dependency_config.get("source"),


### PR DESCRIPTION
Fix repository calls that were missing entity_cls parameter:
- IndexFuturePriceReturnFactorRepository 
- IndexPriceReturnFactorRepository
- FuturePriceReturnFactorRepository
- IndexFutureOptionPriceReturnFactorRepository 
- PortfolioCompanyShareOptionPriceReturnFactorRepository
- PortfolioCompanyShareOptionDeltaFactorRepository

Also add missing frequency parameter to dependency calls where needed.
Resolves 'missing required positional argument entity_cls' errors.

Resolves issue #426

🤖 Generated with [Claude Code](https://claude.ai/code)