### PR TITLE
feat: Add proper IndexFutureOption parameters with ATM strikes for EW

### DIFF
--- a/src/application/managers/project_managers/market_making_SPX_call_spread_project/config.py
+++ b/src/application/managers/project_managers/market_making_SPX_call_spread_project/config.py
@@ -28,8 +28,26 @@ DEFAULT_CONFIG = {
     # Project settings
     'project_name': 'market_making_spx_call_spread',
     'version': '1.0.0',
-    'universe' : {IndexFutureOption: ["EW"],Index: ["SPX"],IndexFuture: ["ESZ6"]},#{Index: ["SPX"],IndexFuture: ["ESZ6"],Index: ["DJL"],IndexFuture: ["MYMZ6"]},
-    'target_factor':{IndexFutureOption: ["EW"],Index: ["SPX"],IndexFuture: ["ESZ6"]},#{Index: ["SPX"],IndexFuture: ["ESZ6"],Index: ["DJL"],IndexFuture: ["MYMZ6"]},
+    'universe' : {
+        IndexFutureOption: [
+            # Russell 2000 (EW) ATM options - March 2026 expiry
+            {"symbol": "EW", "strike_price": 2250.0, "expiry": "20260320", "option_type": "C"},  # ATM Call
+            {"symbol": "EW", "strike_price": 2250.0, "expiry": "20260320", "option_type": "P"},  # ATM Put
+            # Additional strikes for spread strategies
+            {"symbol": "EW", "strike_price": 2200.0, "expiry": "20260320", "option_type": "C"},  # OTM Call
+            {"symbol": "EW", "strike_price": 2300.0, "expiry": "20260320", "option_type": "C"},  # ITM Call
+        ],
+        Index: ["SPX"],
+        IndexFuture: ["ESZ6"]
+    },
+    'target_factor': {
+        IndexFutureOption: [
+            {"symbol": "EW", "strike_price": 2250.0, "expiry": "20260320", "option_type": "C"},  # ATM Call
+            {"symbol": "EW", "strike_price": 2250.0, "expiry": "20260320", "option_type": "P"},  # ATM Put
+        ],
+        Index: ["SPX"],
+        IndexFuture: ["ESZ6"]
+    },
     # SPX Configuration
     'underlying_symbol': 'SPX',
     'underlying_exchange': 'CBOE',

--- a/src/application/managers/project_managers/market_making_SPX_call_spread_project/models/model_trainer.py
+++ b/src/application/managers/project_managers/market_making_SPX_call_spread_project/models/model_trainer.py
@@ -414,9 +414,35 @@ class ModelTrainer:
         entities = []
         universe = self.config.get('universe', {})
         for entity_class, tickers_list in universe.items():
-                for ticker in tickers_list:
-                    entity = self.data_loader.market_data_history_service.market_data_service._get_entity_by_ticker(ticker,entity_class)
+            for ticker_item in tickers_list:
+                # Handle both string format (legacy) and dictionary format (new for IndexFutureOption)
+                if isinstance(ticker_item, dict):
+                    # New format: {"symbol": "EW", "strike_price": 2250.0, "expiry": "20260320", "option_type": "C"}
+                    # For IndexFutureOption, we need to create entity with specific parameters
+                    if entity_class.__name__ == 'IndexFutureOption':
+                        # Use the entity creation service with option parameters
+                        entity_config = {
+                            'entity_class': entity_class,
+                            'entity_symbol': ticker_item['symbol'],
+                            'strike_price': ticker_item.get('strike_price'),
+                            'expiry': ticker_item.get('expiry'),  
+                            'option_type': ticker_item.get('option_type'),
+                            'source': 'config'
+                        }
+                        entity = self.data_loader.market_data_history_service.market_data_service._create_or_get(entity_config)
+                    else:
+                        # For other entity types with dict format, use symbol field
+                        ticker = ticker_item.get('symbol', ticker_item.get('name', str(ticker_item)))
+                        entity = self.data_loader.market_data_history_service.market_data_service._get_entity_by_ticker(ticker, entity_class)
+                else:
+                    # Legacy string format: "EW" or "SPX"
+                    ticker = ticker_item
+                    entity = self.data_loader.market_data_history_service.market_data_service._get_entity_by_ticker(ticker, entity_class)
+                
+                if entity:
                     entities.append(entity)
+                else:
+                    print(f"⚠️  Failed to create/get entity for {ticker_item} (class: {entity_class.__name__})")
         factor_data = self.data_loader.market_data_history_service._create_or_get_factor_value_batch(factor_groups,entities,date)
         
         print(f"✅ Factor data preparation complete: {len(factor_data)} tickers processed")


### PR DESCRIPTION
Fixes #435

Update configuration to include proper option parameters (strike_price, expiry, option_type) for IndexFutureOption entities to resolve IBKR "Cannot send None to TWS" errors.

Changes:
- Add structured IndexFutureOption configuration with ATM strikes for Russell 2000 (EW)
- Include multiple strike levels (2200, 2250, 2300) for spread trading strategies
- Use March 2026 expiry (20260320) for proper monthly options
- Update model_trainer to handle both legacy string and new dictionary formats
- Add backward compatibility for existing configurations
- Enhanced error handling and logging for entity creation failures

Fixes issue where IndexFutureOption factor creation failed due to missing required parameters.

🤖 Generated with [Claude Code](https://claude.ai/code)