### PR TITLE
refactor: Move IndexFutureOption dictionary/string handling logic to MarketDataService

### DIFF
--- a/src/application/managers/project_managers/market_making_SPX_call_spread_project/models/model_trainer.py
+++ b/src/application/managers/project_managers/market_making_SPX_call_spread_project/models/model_trainer.py
@@ -415,29 +415,8 @@ class ModelTrainer:
         universe = self.config.get('universe', {})
         for entity_class, tickers_list in universe.items():
             for ticker_item in tickers_list:
-                # Handle both string format (legacy) and dictionary format (new for IndexFutureOption)
-                if isinstance(ticker_item, dict):
-                    # New format: {"symbol": "EW", "strike_price": 2250.0, "expiry": "20260320", "option_type": "C"}
-                    # For IndexFutureOption, we need to create entity with specific parameters
-                    if entity_class.__name__ == 'IndexFutureOption':
-                        # Use the entity creation service with option parameters
-                        entity_config = {
-                            'entity_class': entity_class,
-                            'entity_symbol': ticker_item['symbol'],
-                            'strike_price': ticker_item.get('strike_price'),
-                            'expiry': ticker_item.get('expiry'),  
-                            'option_type': ticker_item.get('option_type'),
-                            'source': 'config'
-                        }
-                        entity = self.data_loader.market_data_history_service.market_data_service._create_or_get(entity_config)
-                    else:
-                        # For other entity types with dict format, use symbol field
-                        ticker = ticker_item.get('symbol', ticker_item.get('name', str(ticker_item)))
-                        entity = self.data_loader.market_data_history_service.market_data_service._get_entity_by_ticker(ticker, entity_class)
-                else:
-                    # Legacy string format: "EW" or "SPX"
-                    ticker = ticker_item
-                    entity = self.data_loader.market_data_history_service.market_data_service._get_entity_by_ticker(ticker, entity_class)
+                # Use the refactored market_data_service method to handle both dictionary and string formats
+                entity = self.data_loader.market_data_history_service.market_data_service.create_entity_from_ticker_item(ticker_item, entity_class)
                 
                 if entity:
                     entities.append(entity)

--- a/src/application/services/misbuffet/data/market_data_service.py
+++ b/src/application/services/misbuffet/data/market_data_service.py
@@ -293,7 +293,7 @@ class MarketDataService:
             entity_config: Dictionary containing entity configuration with keys:
                 - entity_class: Entity class to create/get
                 - entity_symbol: Entity symbol/identifier
-                - additional parameters for entity creation
+                - additional parameters for entity creation (strike_price, expiry, option_type for options)
         
         Returns:
             Entity if created/retrieved successfully, None otherwise
@@ -306,6 +306,53 @@ class MarketDataService:
                 self.logger.warning("entity_class and entity_symbol are required")
                 return None
             
+            # Special handling for IndexFutureOption - requires option parameters
+            if entity_class.__name__ == 'IndexFutureOption':
+                strike_price = entity_config.get('strike_price')
+                expiry = entity_config.get('expiry')
+                option_type = entity_config.get('option_type')
+                
+                if not strike_price or not expiry or not option_type:
+                    self.logger.warning(f"IndexFutureOption requires strike_price, expiry, and option_type. Got: {entity_config}")
+                    return None
+                
+                # Use IBKR repository if available for options
+                if hasattr(self.entity_service, 'repository_factory'):
+                    try:
+                        # Get the IBKR repository for IndexFutureOption
+                        ibkr_repo = getattr(self.entity_service.repository_factory, 'index_future_option_ibkr_repo', None)
+                        if ibkr_repo:
+                            entity = ibkr_repo._create_or_get(
+                                symbol=entity_symbol,
+                                strike_price=float(strike_price),
+                                expiry=expiry,
+                                option_type=option_type
+                            )
+                            if entity:
+                                self.logger.info(f"Created/retrieved IndexFutureOption via IBKR: {entity_symbol} strike={strike_price} expiry={expiry} type={option_type}")
+                                return entity
+                        
+                        # Fallback to local repository
+                        local_repo = getattr(self.entity_service.repository_factory, 'index_future_option_local_repo', None)
+                        if local_repo:
+                            entity = local_repo._create_or_get(
+                                symbol=entity_symbol,
+                                strike_price=float(strike_price),
+                                expiry=expiry,
+                                option_type=option_type
+                            )
+                            if entity:
+                                self.logger.info(f"Created/retrieved IndexFutureOption via local: {entity_symbol} strike={strike_price} expiry={expiry} type={option_type}")
+                                return entity
+                    
+                    except Exception as e:
+                        self.logger.warning(f"Error creating IndexFutureOption with specific parameters: {e}")
+                        
+                # Final fallback - log the issue but don't create incomplete entity
+                self.logger.warning(f"Failed to create IndexFutureOption {entity_symbol} with required parameters")
+                return None
+            
+            # Standard entity creation for non-option entities
             # Remove entity_class from kwargs to avoid passing it twice
             kwargs = {k: v for k, v in entity_config.items() if k not in ['entity_class', 'entity_symbol']}
             
@@ -325,4 +372,51 @@ class MarketDataService:
             
         except Exception as e:
             self.logger.error(f"Error in MarketDataService._create_or_get: {e}")
+            return None
+    
+    def create_entity_from_ticker_item(self, ticker_item: Union[str, Dict[str, Any]], entity_class: type) -> Optional[Any]:
+        """
+        Create or get an entity from ticker item, handling both dictionary and string formats.
+        
+        This method consolidates the logic for handling entity creation from configuration
+        that was previously in model_trainer.py.
+        
+        Args:
+            ticker_item: Either a string ticker (legacy format) or dictionary with entity parameters
+            entity_class: The entity class to create/get
+            
+        Returns:
+            Entity if created/retrieved successfully, None otherwise
+        """
+        try:
+            if isinstance(ticker_item, dict):
+                # New format: {"symbol": "EW", "strike_price": 2250.0, "expiry": "20260320", "option_type": "C"}
+                # For IndexFutureOption, we need to create entity with specific parameters
+                if entity_class.__name__ == 'IndexFutureOption':
+                    # Use the entity creation service with option parameters
+                    entity_config = {
+                        'entity_class': entity_class,
+                        'entity_symbol': ticker_item['symbol'],
+                        'strike_price': ticker_item.get('strike_price'),
+                        'expiry': ticker_item.get('expiry'),  
+                        'option_type': ticker_item.get('option_type'),
+                        'source': 'config'
+                    }
+                    entity = self._create_or_get(entity_config)
+                else:
+                    # For other entity types with dict format, use symbol field
+                    ticker = ticker_item.get('symbol', ticker_item.get('name', str(ticker_item)))
+                    entity = self._get_entity_by_ticker(ticker, entity_class)
+            else:
+                # Legacy string format: "EW" or "SPX"
+                ticker = ticker_item
+                entity = self._get_entity_by_ticker(ticker, entity_class)
+            
+            if not entity:
+                self.logger.warning(f"Failed to create/get entity for {ticker_item} (class: {entity_class.__name__})")
+            
+            return entity
+            
+        except Exception as e:
+            self.logger.error(f"Error in create_entity_from_ticker_item: {e}")
             return None


### PR DESCRIPTION
Fixes #435

Refactors IndexFutureOption entity creation logic from model_trainer.py into MarketDataService for better separation of concerns and centralized entity management.

## Changes:
- Enhanced MarketDataService._create_or_get() with IndexFutureOption parameter handling
- Added MarketDataService.create_entity_from_ticker_item() for unified entity creation
- Updated model_trainer.py to use refactored market_data_service method
- Maintains backward compatibility for both dictionary and legacy string formats
- Improves separation of concerns by centralizing entity creation logic

## Benefits:
- Better architecture with entity creation in appropriate service layer
- Maintainable centralized IndexFutureOption handling
- Enhanced error handling and logging
- Reusable entity creation logic for other components

This resolves the request to move the IndexFutureOption dictionary/string handling logic from model_trainer.py into the MarketDataService layer.

🤖 Generated with [Claude Code](https://claude.ai/code)