### PR TITLE
fix: Register IndexFutureOptionModel in SQLAlchemy model registry

### DIFF
--- a/src/infrastructure/models/__init__.py
+++ b/src/infrastructure/models/__init__.py
@@ -52,6 +52,7 @@ from src.infrastructure.models.finance.financial_assets.etf_share import ETFShar
 # Complex financial instruments
 from src.infrastructure.models.finance.financial_assets.bond import BondModel
 from src.infrastructure.models.finance.financial_assets.derivative.options import OptionsModel
+from src.infrastructure.models.finance.financial_assets.derivative.option.index_future_option import IndexFutureOptionModel
 from src.infrastructure.models.finance.financial_assets.derivative.future.future import FutureModel
 from src.infrastructure.models.finance.financial_assets.derivative.future.index_future import IndexFutureModel
 from src.infrastructure.models.finance.financial_assets.derivative.derivatives import DerivativeModel
@@ -102,7 +103,8 @@ def ensure_models_registered():
         'CountryModel', 'IndustryModel', 'SectorModel', 'ExchangeModel', 'CompanyModel',
         'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
         'ShareModel', 'CompanyShareModel', 'ETFShareModel', 'PortfolioModel','PortfolioDerivativeModel',
-        'PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 'HoldingModel'
+        'PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 'HoldingModel',
+        'IndexFutureOptionModel', 'IndexFutureModel', 'OptionsModel'
     }
     
     missing = required_models - set(registered)
@@ -130,7 +132,7 @@ __all__ = [
     'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
     'FinancialAssetModel', 'CurrencyModel', 'CashModel', 'CommodityModel', 'SecurityModel', 'EquityModel',
     'ShareModel', 'CompanyShareModel', 'ETFShareModel',
-    'BondModel', 'OptionsModel','FutureModel', 'IndexFutureModel','DerivativeModel',
+    'BondModel', 'OptionsModel', 'IndexFutureOptionModel', 'FutureModel', 'IndexFutureModel','DerivativeModel',
     'ForwardContractModel', 
     'SwapModel',  'SwapLegModel',
     'PortfolioModel','PortfolioDerivativeModel','PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 'SecurityHoldingModel', 


### PR DESCRIPTION
Fixes #435

Resolves SQLAlchemy UnmappedInstanceError when creating IndexFutureOption entities.

## Changes:
- Add missing import for IndexFutureOptionModel in models/__init__.py
- Add IndexFutureOptionModel to __all__ list for proper export
- Add IndexFutureOptionModel to required_models for validation

## Root Cause:
The IndexFutureOptionModel existed but was not imported in the main models __init__.py file, so it wasn't registered with SQLAlchemy's class registry. This caused UnmappedInstanceError when the system tried to create IndexFutureOption entities.

This ensures IndexFutureOption factor creation (like return_daily) succeeds without mapping errors.

🤖 Generated with [Claude Code](https://claude.ai/code)