### PR TITLE
Fix company share entity creation pipeline constructor errors

### DIFF
--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/company_share_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/company_share_repository.py
@@ -245,7 +245,7 @@ class IBKRCompanyShareRepository(IBKRFinancialAssetRepository, CompanySharePort)
             # Apply IBKR-specific business rules and create domain entity
             return CompanyShare(
                 id=None,  # Let database generate
-                ticker=contract.symbol,
+                symbol=contract.symbol,
                 exchange_id=self._resolve_exchange_id(contract.exchange, contract_details),
                 company_id=self._resolve_company_id(contract.symbol, contract_details),
                 start_date=None,  # Will be set based on IBKR data

--- a/src/infrastructure/repositories/local_repo/finance/company_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/company_repository.py
@@ -148,8 +148,12 @@ class CompanyRepository(BaseLocalRepository, CompanyPort):
             if not legal_name:
                 legal_name = name
             
+            # Get next available ID
+            next_id = self._get_next_available_company_id()
+            
             # Create new company
             new_company = CompanyEntity(
+                id=next_id,
                 name=name,
                 legal_name=legal_name,
                 country_id=country_id,

--- a/src/infrastructure/repositories/local_repo/finance/exchange_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/exchange_repository.py
@@ -163,8 +163,12 @@ class ExchangeRepository(BaseLocalRepository, ExchangePort):
             if not legal_name:
                 legal_name = name
             
+            # Get next available ID
+            next_id = self._get_next_available_exchange_id()
+            
             # Create new exchange
             new_exchange = ExchangeEntity(
+                id=next_id,
                 name=name,
                 legal_name=legal_name,
                 country_id=country_id,


### PR DESCRIPTION
Fix company share entity creation pipeline constructor errors

- Fix CompanyShare constructor: change 'ticker=' to 'symbol=' parameter
- Add missing 'id' parameter generation in Company.get_or_create()  
- Add missing 'id' parameter generation in Exchange.get_or_create()
- Align entity creation pattern with index entity structure

Resolves constructor errors:
- CompanyShare.__init__() got unexpected keyword argument 'ticker'
- Company.__init__() missing 1 required positional argument: 'id'  
- Exchange.__init__() missing 1 required positional argument: 'id'

Generated with [Claude Code](https://claude.ai/code)