### PR TITLE
Fix company share entity creation pipeline - additional issues

### DIFF
--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/company_share_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/company_share_repository.py
@@ -243,20 +243,15 @@ class IBKRCompanyShareRepository(IBKRFinancialAssetRepository, CompanySharePort)
         """
         try:
             # Apply IBKR-specific business rules and create domain entity
+            # Note: IBKR-specific metadata (contract_id, trading_class, etc.) 
+            # can be stored separately or via repository metadata if needed
             return CompanyShare(
                 id=None,  # Let database generate
                 symbol=contract.symbol,
                 exchange_id=self._resolve_exchange_id(contract.exchange, contract_details),
                 company_id=self._resolve_company_id(contract.symbol, contract_details),
                 start_date=None,  # Will be set based on IBKR data
-                end_date=None,    # Active securities don't have end dates
-                # Additional IBKR-specific fields can be stored as metadata
-                ibkr_contract_id=getattr(contract, 'conId', None),
-                ibkr_local_symbol=getattr(contract, 'localSymbol', ''),
-                ibkr_trading_class=getattr(contract, 'tradingClass', ''),
-                ibkr_long_name=getattr(contract_details, 'longName', ''),
-                ibkr_industry=getattr(contract_details, 'industry', ''),
-                ibkr_category=getattr(contract_details, 'category', '')
+                end_date=None     # Active securities don't have end dates
             )
         except Exception as e:
             print(f"Error converting IBKR contract to domain entity: {e}")

--- a/src/infrastructure/repositories/local_repo/finance/company_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/company_repository.py
@@ -127,7 +127,7 @@ class CompanyRepository(BaseLocalRepository, CompanyPort):
             name: Company name
             legal_name: Legal name (optional, will default to name if not provided)
             country_id: Country ID (optional, will use default if not provided)
-            industry_id: Industry ID (optional)
+            industry_id: Industry ID (optional, will use default if not provided)
             
         Returns:
             Domain company entity or None if creation failed
@@ -143,6 +143,12 @@ class CompanyRepository(BaseLocalRepository, CompanyPort):
                 country_local_repo = self.factory.country_local_repo
                 default_country = country_local_repo._create_or_get(name="Global", iso_code="GL")
                 country_id = default_country.id if default_country else 1
+            
+            # Get or create industry dependency if not provided
+            if not industry_id:
+                industry_local_repo = self.factory.industry_local_repo
+                default_industry = industry_local_repo._create_or_get(name="Technology", description="Technology sector")
+                industry_id = default_industry.id if default_industry else 1
             
             # Set default legal name
             if not legal_name:
@@ -198,7 +204,7 @@ class CompanyRepository(BaseLocalRepository, CompanyPort):
             name: Company name (unique identifier)
             legal_name: Legal name (defaults to name if not provided)
             country_id: Country ID (defaults to 1 - USA)
-            industry_id: Industry ID (defaults to 1 - Technology)
+            industry_id: Industry ID (defaults to 1 - Technology, will create if needed)
             start_date: Start date (defaults to current date)
             
         Returns:
@@ -210,6 +216,12 @@ class CompanyRepository(BaseLocalRepository, CompanyPort):
             return existing_companies[0] if existing_companies else None
         
         try:
+            # Ensure industry exists - create default if ID 1 doesn't exist
+            if industry_id == 1:
+                industry_local_repo = self.factory.industry_local_repo
+                default_industry = industry_local_repo._create_or_get(name="Technology", description="Technology sector")
+                industry_id = default_industry.id if default_industry else 1
+            
             # Get next available ID
             next_id = self._get_next_available_company_id()
             


### PR DESCRIPTION
Fix company share entity creation pipeline - additional issues

- Fix missing industry_id constraint in Company entity creation
- Add industry dependency resolution in get_or_create methods
- Remove invalid constructor parameters from CompanyShare IBKR conversion
- Prevent SQL Server integrity errors and transaction rollbacks
- Align with existing index entity patterns for dependency handling

Resolves:
- SQL Server error: Cannot insert NULL into industry_id column  
- Constructor error: unexpected keyword argument 'ibkr_contract_id'
- Transaction rollback cascading to other repository operations

Generated with [Claude Code](https://claude.ai/code)