### PR TITLE
Fix company share entity creation pipeline constructor errors

### DIFF
--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/share_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/share_repository.py
@@ -165,16 +165,11 @@ class IBKRShareRepository(IBKRFinancialAssetRepository, SharePort):
             
             return Share(
                 id=None,  # Let database generate
-                ticker=contract.symbol,
+                name=contract.symbol,  # Use symbol as name
+                symbol=contract.symbol,
                 exchange_id=self._resolve_exchange_id(contract.exchange),
-                company_id=self._resolve_company_id(contract.symbol),
                 start_date=None,
-                end_date=None,
-                # IBKR-specific fields
-                ibkr_contract_id=getattr(contract, 'conId', None),
-                ibkr_local_symbol=getattr(contract, 'localSymbol', ''),
-                ibkr_trading_class=getattr(contract, 'tradingClass', ''),
-                ibkr_primary_exchange=getattr(contract, 'primaryExchange', '')
+                end_date=None
             )
         except Exception as e:
             print(f"Error converting IBKR share contract to domain entity: {e}")

--- a/src/infrastructure/repositories/local_repo/geographic/industry_repository.py
+++ b/src/infrastructure/repositories/local_repo/geographic/industry_repository.py
@@ -115,8 +115,7 @@ class IndustryRepository(GeographicRepository, IndustryPort):
                 id=next_id,
                 name=name,
                 sector_id=1,  # Default sector ID
-                description=description or "",
-                key_metrics=[]  # Empty list for key metrics
+                description=description or ""
             )
             
             # Convert to ORM model and add to database

--- a/src/infrastructure/repositories/mappers/industry_mapper.py
+++ b/src/infrastructure/repositories/mappers/industry_mapper.py
@@ -16,13 +16,12 @@ class IndustryMapper:
     @staticmethod
     def to_domain(orm_obj: ORMIndustry) -> DomainIndustry:
         """Convert ORM model to domain entity."""
-        # Create domain entity with correct constructor parameters: (id, name, sector_id, description, key_metrics)
+        # Create domain entity with correct constructor parameters: (id, name, sector_id, description)
         domain_entity = DomainIndustry(
             id=orm_obj.id,
             name=orm_obj.name,
             sector_id=orm_obj.sector_id,
-            description=getattr(orm_obj, 'description', ''),
-            key_metrics=[]  # Default empty list for key metrics
+            description=getattr(orm_obj, 'description', '')
         )
         
         return domain_entity


### PR DESCRIPTION
Fix company share entity creation pipeline constructor errors

- Fix Industry constructor: remove invalid 'key_metrics' parameter
- Fix Share constructor: use correct parameters (name, symbol, exchange_id)  
- Remove IBKR metadata from Share domain entity constructor
- Update industry mapper to match domain entity constructor signature

Resolves constructor errors:
- Industry.__init__() got unexpected keyword argument 'key_metrics'
- Share.__init__() missing required positional argument: 'exchange_id'  
- Foreign key constraint violations due to failed industry creation

Generated with [Claude Code](https://claude.ai/code)