### PR TITLE
feat: Add CompanyShareOption pipeline components

### DIFF
--- a/src/domain/entities/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_price_return_factor.py
+++ b/src/domain/entities/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_price_return_factor.py
@@ -1,0 +1,162 @@
+import math
+from typing import Optional
+
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.company_share_option.company_share_option_factor import CompanyShareOptionFactor
+
+
+class CompanyShareOptionPriceReturnFactor(CompanyShareOptionFactor):
+    """Price return factor associated with company share options."""
+
+    def __init__(
+        self,
+        factor_id: Optional[int] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            name="Company Share Option Price Return",
+            group="Company Share Option Factor",
+            subgroup="Price Return",
+            data_type="float",
+            source="calculated",
+            definition="Price return of company share option calculated as percentage change in option value.",
+            factor_id=factor_id,
+            **kwargs,
+        )
+
+    def calculate_price_return(
+        self,
+        current_price: float,
+        previous_price: float,
+    ) -> Optional[float]:
+        """
+        Calculate the price return as percentage change.
+        
+        Args:
+            current_price: Current option price
+            previous_price: Previous option price
+            
+        Returns:
+            Price return as decimal (e.g., 0.05 for 5% return)
+        """
+        if previous_price <= 0:
+            return None
+            
+        return (current_price - previous_price) / previous_price
+
+    def calculate_log_return(
+        self,
+        current_price: float,
+        previous_price: float,
+    ) -> Optional[float]:
+        """
+        Calculate the logarithmic return.
+        
+        Args:
+            current_price: Current option price
+            previous_price: Previous option price
+            
+        Returns:
+            Log return as decimal
+        """
+        if current_price <= 0 or previous_price <= 0:
+            return None
+            
+        return math.log(current_price / previous_price)
+
+    def calculate_volatility_adjusted_return(
+        self,
+        current_price: float,
+        previous_price: float,
+        volatility: float,
+        time_period: float = 1.0,
+    ) -> Optional[float]:
+        """
+        Calculate volatility-adjusted return (return per unit of volatility).
+        
+        Args:
+            current_price: Current option price
+            previous_price: Previous option price
+            volatility: Option's implied volatility
+            time_period: Time period for the return (in years)
+            
+        Returns:
+            Volatility-adjusted return
+        """
+        if volatility <= 0 or previous_price <= 0:
+            return None
+            
+        price_return = self.calculate_price_return(current_price, previous_price)
+        if price_return is None:
+            return None
+            
+        # Adjust for time period and volatility
+        annualized_return = price_return / time_period
+        return annualized_return / volatility
+
+    def calculate_sharpe_ratio(
+        self,
+        option_return: float,
+        risk_free_rate: float,
+        return_volatility: float,
+    ) -> Optional[float]:
+        """
+        Calculate Sharpe ratio for the option returns.
+        
+        Args:
+            option_return: Option return
+            risk_free_rate: Risk-free rate
+            return_volatility: Volatility of option returns
+            
+        Returns:
+            Sharpe ratio
+        """
+        if return_volatility <= 0:
+            return None
+            
+        excess_return = option_return - risk_free_rate
+        return excess_return / return_volatility
+
+    def calculate_underlying_correlation_return(
+        self,
+        option_return: float,
+        underlying_stock_return: float,
+    ) -> Optional[float]:
+        """
+        Calculate return adjusted for correlation with underlying company share.
+        
+        Args:
+            option_return: Option return
+            underlying_stock_return: Return of underlying company share
+            
+        Returns:
+            Correlation-adjusted return measure
+        """
+        if underlying_stock_return == 0:
+            return None
+            
+        # Beta-like measure of option sensitivity to underlying stock moves
+        return option_return / underlying_stock_return
+
+    def calculate_delta_adjusted_return(
+        self,
+        option_return: float,
+        option_delta: float,
+        underlying_return: float,
+    ) -> Optional[float]:
+        """
+        Calculate delta-adjusted return to isolate non-directional components.
+        
+        Args:
+            option_return: Option return
+            option_delta: Option delta (sensitivity to underlying)
+            underlying_return: Return of underlying stock
+            
+        Returns:
+            Delta-adjusted return
+        """
+        if option_delta == 0:
+            return option_return
+            
+        # Remove the expected return from delta exposure
+        expected_delta_return = option_delta * underlying_return
+        return option_return - expected_delta_return

--- a/src/domain/ports/factor/company_share_option_price_return_factor_port.py
+++ b/src/domain/ports/factor/company_share_option_price_return_factor_port.py
@@ -1,0 +1,117 @@
+"""
+CompanyShareOptionPriceReturnFactor Port - Repository interface for CompanyShareOptionPriceReturnFactor entities.
+
+This port defines the contract for repositories that handle CompanyShareOptionPriceReturnFactor
+entities, ensuring both local and external data source repositories implement the same interface.
+Follows the same pattern as other factor ports in the system.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, List
+
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.company_share_option.company_share_option_price_return_factor import CompanyShareOptionPriceReturnFactor
+
+
+class CompanyShareOptionPriceReturnFactorPort(ABC):
+    """Port interface for CompanyShareOptionPriceReturnFactor repositories"""
+    
+    # @abstractmethod
+    # def get_by_id(self, entity_id: int) -> Optional[CompanyShareOptionPriceReturnFactor]:
+    #     """
+    #     Get company share option price return factor by ID.
+        
+    #     Args:
+    #         entity_id: The entity ID
+            
+    #     Returns:
+    #         CompanyShareOptionPriceReturnFactor entity or None if not found
+    #     """
+    #     pass
+    
+    # @abstractmethod
+    # def get_by_name(self, name: str) -> Optional[CompanyShareOptionPriceReturnFactor]:
+    #     """
+    #     Get company share option price return factor by name.
+        
+    #     Args:
+    #         name: The factor name
+            
+    #     Returns:
+    #         CompanyShareOptionPriceReturnFactor entity or None if not found
+    #     """
+    #     pass
+    
+    # @abstractmethod
+    # def get_by_group(self, group: str) -> List[CompanyShareOptionPriceReturnFactor]:
+    #     """
+    #     Get company share option price return factors by group.
+        
+    #     Args:
+    #         group: The factor group
+            
+    #     Returns:
+    #         List of CompanyShareOptionPriceReturnFactor entities in the group
+    #     """
+    #     pass
+    
+    # @abstractmethod
+    # def get_by_subgroup(self, subgroup: str) -> List[CompanyShareOptionPriceReturnFactor]:
+    #     """
+    #     Get company share option price return factors by subgroup.
+        
+    #     Args:
+    #         subgroup: The factor subgroup
+            
+    #     Returns:
+    #         List of CompanyShareOptionPriceReturnFactor entities in the subgroup
+    #     """
+    #     pass
+    
+    # @abstractmethod
+    # def get_all(self) -> List[CompanyShareOptionPriceReturnFactor]:
+    #     """
+    #     Get all company share option price return factors.
+        
+    #     Returns:
+    #         List of CompanyShareOptionPriceReturnFactor entities
+    #     """
+    #     pass
+    
+    # @abstractmethod
+    # def add(self, entity: CompanyShareOptionPriceReturnFactor) -> Optional[CompanyShareOptionPriceReturnFactor]:
+    #     """
+    #     Add/persist a company share option price return factor entity.
+        
+    #     Args:
+    #         entity: The CompanyShareOptionPriceReturnFactor entity to persist
+            
+    #     Returns:
+    #         Persisted CompanyShareOptionPriceReturnFactor entity or None if failed
+    #     """
+    #     pass
+    
+    # @abstractmethod
+    # def update(self, entity: CompanyShareOptionPriceReturnFactor) -> Optional[CompanyShareOptionPriceReturnFactor]:
+    #     """
+    #     Update a company share option price return factor entity.
+        
+    #     Args:
+    #         entity: The CompanyShareOptionPriceReturnFactor entity to update
+            
+    #     Returns:
+    #         Updated CompanyShareOptionPriceReturnFactor entity or None if failed
+    #     """
+    #     pass
+    
+    # @abstractmethod
+    # def delete(self, entity_id: int) -> bool:
+    #     """
+    #     Delete a company share option price return factor entity.
+        
+    #     Args:
+    #         entity_id: The entity ID to delete
+            
+    #     Returns:
+    #         True if deleted successfully, False otherwise
+    #     """
+    #     pass

--- a/src/infrastructure/models/__init__.py
+++ b/src/infrastructure/models/__init__.py
@@ -52,6 +52,7 @@ from src.infrastructure.models.finance.financial_assets.etf_share import ETFShar
 # Complex financial instruments
 from src.infrastructure.models.finance.financial_assets.bond import BondModel
 from src.infrastructure.models.finance.financial_assets.derivative.option.options import OptionsModel
+from src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option import CompanyShareOptionModel
 from src.infrastructure.models.finance.financial_assets.derivative.option.index_future_option import IndexFutureOptionModel
 from src.infrastructure.models.finance.financial_assets.derivative.future.future import FutureModel
 from src.infrastructure.models.finance.financial_assets.derivative.future.index_future import IndexFutureModel
@@ -104,7 +105,7 @@ def ensure_models_registered():
         'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
         'ShareModel', 'CompanyShareModel', 'ETFShareModel', 'PortfolioModel','PortfolioDerivativeModel',
         'PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 'HoldingModel',
-        'IndexFutureOptionModel', 'IndexFutureModel', 'OptionsModel'
+        'IndexFutureOptionModel', 'IndexFutureModel', 'OptionsModel', 'CompanyShareOptionModel'
     }
     
     missing = required_models - set(registered)
@@ -132,7 +133,7 @@ __all__ = [
     'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
     'FinancialAssetModel', 'CurrencyModel', 'CashModel', 'CommodityModel', 'SecurityModel', 'EquityModel',
     'ShareModel', 'CompanyShareModel', 'ETFShareModel',
-    'BondModel', 'OptionsModel', 'IndexFutureOptionModel', 'FutureModel', 'IndexFutureModel','DerivativeModel',
+    'BondModel', 'OptionsModel', 'CompanyShareOptionModel', 'IndexFutureOptionModel', 'FutureModel', 'IndexFutureModel','DerivativeModel',
     'ForwardContractModel', 
     'SwapModel',  'SwapLegModel',
     'PortfolioModel','PortfolioDerivativeModel','PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 'SecurityHoldingModel', 

--- a/src/infrastructure/models/factor/factor.py
+++ b/src/infrastructure/models/factor/factor.py
@@ -125,3 +125,16 @@ class PortfolioCompanyShareOptionDeltaFactorModel(FactorModel):
     __mapper_args__ = {
         "polymorphic_identity": "portfolio_company_share_option_delta_factor"
     }
+
+
+# Company Share Option Factor Models
+class CompanyShareOptionFactorModel(FactorModel):
+    __mapper_args__ = {
+        "polymorphic_identity": "company_share_option_factor"
+    }
+
+
+class CompanyShareOptionPriceReturnFactorModel(FactorModel):
+    __mapper_args__ = {
+        "polymorphic_identity": "company_share_option_price_return_factor"
+    }

--- a/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
@@ -1,0 +1,29 @@
+"""
+ORM model for CompanyShareOptions - separate from src.domain entity to avoid metaclass conflicts.
+"""
+
+from sqlalchemy import Column, Integer, String, Date, Numeric, Boolean, DateTime, Text
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import relationship
+from src.infrastructure.models import ModelBase as Base
+from src.infrastructure.models.finance.financial_assets.derivative.option.options import OptionsModel
+
+
+class CompanyShareOptionModel(OptionsModel):
+    """
+    SQLAlchemy ORM model for Company Share Options.
+    Completely separate from src.domain entity to avoid metaclass conflicts.
+    """
+    __tablename__ = 'company_share_options'
+
+    id = Column(Integer, ForeignKey("options.id"), primary_key=True)
+    
+    # Additional fields specific to company share options can be added here
+    # For example: strike_price, expiration_date, contract_size, etc.
+    
+    __mapper_args__ = {
+        "polymorphic_identity": "company_share_option",
+    }
+    
+    def __repr__(self):
+        return f"<CompanyShareOption(id={self.id}, symbol={self.symbol})>"

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/company_share_option_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/company_share_option_price_return_factor_repository.py
@@ -1,0 +1,55 @@
+"""
+Repository class for Company Share Option Price Return factor entities.
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from src.domain.entities.factor.factor_dependency import FactorDependency
+from src.infrastructure.repositories.mappers.factor.company_share_option_price_return_factor_mapper import CompanyShareOptionPriceReturnFactorMapper
+from src.infrastructure.repositories.mappers.factor.factor_value_mapper import FactorValueMapper
+from ...base_factor_repository import BaseFactorRepository
+
+
+class CompanyShareOptionPriceReturnFactorRepository(BaseFactorRepository):
+    """Repository for Company Share Option Price Return factor entities with CRUD operations."""
+    
+    def __init__(self, session: Session, factory=None):
+        super().__init__(session)
+        self.factory = factory
+        self.mapper = CompanyShareOptionPriceReturnFactorMapper()
+
+    @property
+    def entity_class(self):
+        return self.get_factor_entity()
+
+    def get_factor_model(self):
+        return self.mapper.get_factor_model()
+    
+    def get_factor_entity(self):
+        return self.mapper.get_factor_entity()
+
+    @property
+    def model_class(self):
+        return self.mapper.model_class
+
+    def get_by_id(self, id: int):
+        return (
+            self.session
+            .query(self.model_class)
+            .filter(self.model_class.id == id)
+            .one_or_none()
+        )
+    
+    def get_factor_value_model(self):
+        return FactorValueMapper().get_factor_value_model()
+    
+    def get_factor_value_entity(self):
+        return FactorValueMapper().get_factor_value_entity()
+
+    def _to_entity(self, infra_obj):
+        """Convert ORM model to domain entity."""
+        return self.mapper.to_domain(infra_obj)
+    
+    def _to_infra(self, entity):
+        """Convert domain entity to ORM model."""
+        return self.mapper.to_orm(entity)

--- a/src/infrastructure/repositories/local_repo/finance/financial_assets/derivatives/option/company_share_option_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/financial_assets/derivatives/option/company_share_option_repository.py
@@ -1,0 +1,162 @@
+"""
+CompanyShareOption Repository for local database operations.
+Follows the same patterns as other repositories in the project.
+"""
+
+import logging
+from typing import List, Optional, Dict, Any
+from decimal import Decimal
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+from src.domain.entities.finance.financial_assets.derivatives.option.company_share_option import CompanyShareOption as DomainCompanyShareOption
+from src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option import CompanyShareOptionModel as ORMCompanyShareOption
+from src.infrastructure.repositories.mappers.finance.financial_assets.options_mapper import OptionsMapper
+from src.infrastructure.repositories.local_repo.finance.financial_assets.derivatives.options_repository import OptionsRepository
+
+logger = logging.getLogger(__name__)
+
+
+class CompanyShareOptionRepository(OptionsRepository):
+    """Repository for company share option operations in the local database."""
+
+    def __init__(self, session: Session, factory):
+        """Initialize CompanyShareOptionRepository with database session."""
+        super().__init__(session, factory)
+        self.mapper = OptionsMapper()
+    
+    @property
+    def model_class(self):
+        """Return the SQLAlchemy model class for CompanyShareOptions."""
+        return ORMCompanyShareOption
+    
+    @property
+    def entity_class(self):
+        """Return the domain entity class for CompanyShareOptions."""
+        return DomainCompanyShareOption
+
+    def get_or_create(self, ticker: str = None, name: str = None, symbol: str = None, 
+                      currency_code: str = "USD", option_type: str = None, 
+                      underlying_asset_id: int = None) -> Optional[DomainCompanyShareOption]:
+        """
+        Get or create a company share option with dependency resolution.
+        
+        Args:
+            ticker: Option ticker (optional)
+            name: Option name (optional)
+            symbol: Option symbol (optional) 
+            currency_code: Currency ISO code (default: USD)
+            option_type: Type of option (CALL/PUT)
+            underlying_asset_id: Required ID of the underlying company share
+            
+        Returns:
+            Domain company share option entity or None if creation failed
+        """
+        try:
+            # First try to get existing option by ticker or symbol
+            if ticker:
+                existing = self.get_by_ticker(ticker)
+                if existing:
+                    return existing
+            elif symbol:
+                existing = self.get_by_symbol(symbol)
+                if existing:
+                    return existing
+            
+            # Validate underlying asset exists and is a company share if provided
+            if underlying_asset_id:
+                from src.infrastructure.models.finance.financial_assets.company_share import CompanyShareModel
+                # Query to check if underlying company share exists
+                underlying_exists = self.session.query(CompanyShareModel).filter(
+                    CompanyShareModel.id == underlying_asset_id
+                ).first()
+                
+                if not underlying_exists:
+                    logger.error(f"Underlying company share with ID {underlying_asset_id} does not exist")
+                    return None
+            
+            # Get or create currency dependency
+            currency_local_repo = self.factory.currency_local_repo
+            currency = currency_local_repo.get_or_create(iso_code=currency_code)
+            
+            # Create new company share option
+            new_option = DomainCompanyShareOption(
+                id=None,
+                name=name or f"Company Share Option {ticker or symbol}",
+                symbol=symbol or ticker,
+                currency_id=currency.asset_id if currency else None,
+                underlying_asset_id=underlying_asset_id,
+                option_type=option_type or "call"
+            )
+            
+            return self.add(new_option)
+            
+        except Exception as e:
+            logger.error(f"Error in get_or_create for company share option {ticker or symbol}: {e}")
+            return None
+
+    def get_by_company_share_id(self, company_share_id: int) -> List[DomainCompanyShareOption]:
+        """
+        Retrieve company share options by their underlying company share ID.
+        
+        Args:
+            company_share_id: ID of the underlying company share
+            
+        Returns:
+            List of domain company share option entities
+        """
+        try:
+            orm_options = self.session.query(ORMCompanyShareOption).filter(
+                ORMCompanyShareOption.underlying_asset_id == company_share_id
+            ).all()
+            
+            return [self.mapper.to_domain(orm_option) for orm_option in orm_options]
+            
+        except Exception as e:
+            logger.error(f"Error retrieving company share options by company share ID {company_share_id}: {e}")
+            raise
+
+    def get_by_option_type(self, option_type: str) -> List[DomainCompanyShareOption]:
+        """
+        Retrieve company share options by their option type.
+        
+        Args:
+            option_type: Type of option (call/put)
+            
+        Returns:
+            List of domain company share option entities
+        """
+        try:
+            orm_options = self.session.query(ORMCompanyShareOption).filter(
+                ORMCompanyShareOption.option_type == option_type.lower()
+            ).all()
+            
+            return [self.mapper.to_domain(orm_option) for orm_option in orm_options]
+            
+        except Exception as e:
+            logger.error(f"Error retrieving company share options by option type {option_type}: {e}")
+            raise
+
+    def get_active_options(self) -> List[DomainCompanyShareOption]:
+        """
+        Retrieve all active company share options (end_date is None or in the future).
+        
+        Returns:
+            List of active domain company share option entities
+        """
+        try:
+            from datetime import date
+            current_date = date.today()
+            
+            orm_options = self.session.query(ORMCompanyShareOption).filter(
+                (ORMCompanyShareOption.end_date.is_(None)) | 
+                (ORMCompanyShareOption.end_date > current_date)
+            ).all()
+            
+            return [self.mapper.to_domain(orm_option) for orm_option in orm_options]
+            
+        except Exception as e:
+            logger.error(f"Error retrieving active company share options: {e}")
+            raise

--- a/src/infrastructure/repositories/mappers/factor/company_share_option_price_return_factor_mapper.py
+++ b/src/infrastructure/repositories/mappers/factor/company_share_option_price_return_factor_mapper.py
@@ -1,0 +1,63 @@
+"""
+Mapper for CompanyShareOptionPriceReturnFactor domain entity and ORM model conversion.
+"""
+
+from typing import Optional
+
+from src.infrastructure.models.factor.factor import CompanyShareOptionPriceReturnFactorModel
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.company_share_option.company_share_option_price_return_factor import CompanyShareOptionPriceReturnFactor
+from .base_factor_mapper import BaseFactorMapper
+
+
+class CompanyShareOptionPriceReturnFactorMapper(BaseFactorMapper):
+    """Mapper for CompanyShareOptionPriceReturnFactor domain entity and ORM model conversion."""
+    
+    @property
+    def discriminator(self):
+        return 'company_share_option_price_return_factor'
+    
+    @property
+    def model_class(self):
+        return CompanyShareOptionPriceReturnFactorModel
+    
+    def get_factor_model(self):
+        return CompanyShareOptionPriceReturnFactorModel
+    
+    def get_factor_entity(self):
+        return CompanyShareOptionPriceReturnFactor
+    
+    @classmethod
+    def to_domain(cls, orm_model: Optional[CompanyShareOptionPriceReturnFactorModel]) -> Optional[CompanyShareOptionPriceReturnFactor]:
+        """Convert ORM model to CompanyShareOptionPriceReturnFactor domain entity."""
+        if not orm_model:
+            return None
+        
+        return CompanyShareOptionPriceReturnFactor(
+            name=orm_model.name,
+            group=orm_model.group,
+            subgroup=orm_model.subgroup,
+            data_type=orm_model.data_type,
+            source=orm_model.source,
+            definition=orm_model.definition,
+            factor_id=orm_model.id,
+            current_price=getattr(orm_model, 'current_price', None),
+            previous_price=getattr(orm_model, 'previous_price', None),
+            underlying_symbol=getattr(orm_model, 'underlying_symbol', None)
+        )
+    
+    @classmethod
+    def to_orm(cls, domain_entity: CompanyShareOptionPriceReturnFactor):
+        """Convert CompanyShareOptionPriceReturnFactor domain entity to ORM model."""
+        return CompanyShareOptionPriceReturnFactorModel(
+            id=domain_entity.factor_id,
+            name=domain_entity.name,
+            group=domain_entity.group,
+            subgroup=domain_entity.subgroup,
+            data_type=domain_entity.data_type,
+            source=domain_entity.source,
+            definition=domain_entity.definition,
+            discriminator=cls().discriminator,
+            current_price=getattr(domain_entity, 'current_price', None),
+            previous_price=getattr(domain_entity, 'previous_price', None),
+            underlying_symbol=getattr(domain_entity, 'underlying_symbol', None)
+        )

--- a/src/infrastructure/repositories/mappers/finance/financial_assets/company_share_option_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/financial_assets/company_share_option_mapper.py
@@ -1,0 +1,65 @@
+"""
+Mapper for CompanyShareOption domain entity and ORM model.
+Converts between domain entities and ORM models to avoid metaclass conflicts.
+"""
+
+from typing import Optional
+from datetime import datetime
+
+from src.domain.entities.finance.financial_assets.derivatives.option.company_share_option import CompanyShareOption as DomainCompanyShareOption
+from src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option import CompanyShareOptionModel as ORMCompanyShareOption
+
+
+class CompanyShareOptionMapper:
+    """Mapper for CompanyShareOption domain entity and ORM model."""
+
+    @staticmethod
+    def to_domain(orm_obj: ORMCompanyShareOption) -> DomainCompanyShareOption:
+        """Convert ORM model to domain entity."""
+        domain_entity = DomainCompanyShareOption(
+            id=orm_obj.id,
+            name=getattr(orm_obj, 'name', None),
+            symbol=getattr(orm_obj, 'symbol', None),
+            currency_id=getattr(orm_obj, 'currency_id', None),
+            underlying_asset_id=getattr(orm_obj, 'underlying_asset_id', None),
+            option_type=getattr(orm_obj, 'option_type', None),
+            start_date=getattr(orm_obj, 'start_date', None),
+            end_date=getattr(orm_obj, 'end_date', None)
+        )
+        
+        return domain_entity
+
+    @staticmethod
+    def to_orm(domain_obj: DomainCompanyShareOption, orm_obj: Optional[ORMCompanyShareOption] = None) -> ORMCompanyShareOption:
+        """Convert domain entity to ORM model."""
+        if orm_obj is None:
+            orm_obj = ORMCompanyShareOption()
+        
+        # Map basic fields
+        orm_obj.id = domain_obj.id
+        
+        # Map company share option specific fields
+        if hasattr(domain_obj, 'option_type'):
+            orm_obj.option_type = domain_obj.option_type
+        if hasattr(domain_obj, 'currency_id'):
+            orm_obj.currency_id = domain_obj.currency_id
+        if hasattr(domain_obj, 'underlying_asset_id'):
+            orm_obj.underlying_asset_id = domain_obj.underlying_asset_id
+        
+        # Map optional financial asset attributes
+        if hasattr(domain_obj, 'name'):
+            orm_obj.name = domain_obj.name
+        if hasattr(domain_obj, 'symbol'):
+            orm_obj.symbol = domain_obj.symbol
+        if hasattr(domain_obj, 'start_date'):
+            orm_obj.start_date = domain_obj.start_date
+        if hasattr(domain_obj, 'end_date'):
+            orm_obj.end_date = domain_obj.end_date
+        
+        # Set timestamps if they exist on the model
+        if hasattr(orm_obj, 'created_at') and not orm_obj.created_at:
+            orm_obj.created_at = datetime.now()
+        if hasattr(orm_obj, 'updated_at'):
+            orm_obj.updated_at = datetime.now()
+        
+        return orm_obj

--- a/src/infrastructure/repositories/repository_factory.py
+++ b/src/infrastructure/repositories/repository_factory.py
@@ -52,6 +52,7 @@ from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.index_future_option_price_factor_repository import IndexFutureOptionPriceFactorRepository
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.index_future_option_delta_factor_repository import IndexFutureOptionDeltaFactorRepository
 from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.options_factor_repository import OptionsFactorRepository
+from src.infrastructure.repositories.local_repo.factor.finance.financial_assets.company_share_option_price_return_factor_repository import CompanyShareOptionPriceReturnFactorRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.bond_repository import BondRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.cash_repository import CashRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.commodity_repository import CommodityRepository
@@ -62,6 +63,7 @@ from src.infrastructure.repositories.local_repo.finance.financial_assets.equity_
 from src.infrastructure.repositories.local_repo.finance.financial_assets.etf_share_repository import ETFShareRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.derivatives.future.index_future_repository import IndexFutureRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.derivatives.option.index_future_option_repository import IndexFutureOptionRepository
+from src.infrastructure.repositories.local_repo.finance.financial_assets.derivatives.option.company_share_option_repository import CompanyShareOptionRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.index_repository import IndexRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.security_repository import SecurityRepository
 from src.infrastructure.repositories.local_repo.finance.financial_assets.share_repository import ShareRepository
@@ -173,8 +175,10 @@ class RepositoryFactory:
                 'index_future_option_price_factor': IndexFutureOptionPriceFactorRepository(self.session, factory=self),
                 'index_future_option_delta_factor': IndexFutureOptionDeltaFactorRepository(self.session, factory=self),
                 'option_factor': OptionsFactorRepository(self.session, factory=self),
+                'company_share_option_price_return_factor': CompanyShareOptionPriceReturnFactorRepository(self.session, factory=self),
                 'index_future': IndexFutureRepository(self.session, factory=self),
                 'index_future_option': IndexFutureOptionRepository(self.session, factory=self),
+                'company_share_option': CompanyShareOptionRepository(self.session, factory=self),
                 'company_share': CompanyShareRepository(self.session, factory=self),
                 'currency': CurrencyRepository(self.session, factory=self),
                 'bond': BondRepository(self.session, factory=self),

--- a/tests/test_company_share_option_pipeline.py
+++ b/tests/test_company_share_option_pipeline.py
@@ -1,0 +1,182 @@
+"""
+Test suite for CompanyShareOption pipeline components.
+Tests the creation and functionality of CompanyShareOption entities and their factors.
+"""
+
+import unittest
+from decimal import Decimal
+from datetime import date, datetime
+
+from src.domain.entities.finance.financial_assets.derivatives.option.company_share_option import CompanyShareOption
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.company_share_option.company_share_option_factor import CompanyShareOptionFactor
+from src.domain.entities.factor.finance.financial_assets.derivatives.option.company_share_option.company_share_option_price_return_factor import CompanyShareOptionPriceReturnFactor
+from src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option import CompanyShareOptionModel
+from src.infrastructure.models.factor.factor import CompanyShareOptionFactorModel, CompanyShareOptionPriceReturnFactorModel
+from src.infrastructure.repositories.mappers.finance.financial_assets.company_share_option_mapper import CompanyShareOptionMapper
+from src.infrastructure.repositories.mappers.factor.company_share_option_price_return_factor_mapper import CompanyShareOptionPriceReturnFactorMapper
+
+
+class TestCompanyShareOptionDomainEntity(unittest.TestCase):
+    """Test the CompanyShareOption domain entity."""
+
+    def test_company_share_option_creation(self):
+        """Test creating a CompanyShareOption domain entity."""
+        option = CompanyShareOption(
+            id=1,
+            name="AAPL Call Option",
+            symbol="AAPL240315C150",
+            currency_id=1,
+            underlying_asset_id=100,
+            option_type="call",
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 3, 15)
+        )
+
+        self.assertEqual(option.id, 1)
+        self.assertEqual(option.name, "AAPL Call Option")
+        self.assertEqual(option.symbol, "AAPL240315C150")
+        self.assertEqual(option.currency_id, 1)
+        self.assertEqual(option.underlying_asset_id, 100)
+        self.assertEqual(option.option_type, "call")
+        self.assertEqual(option.start_date, date(2024, 1, 1))
+        self.assertEqual(option.end_date, date(2024, 3, 15))
+
+
+class TestCompanyShareOptionFactor(unittest.TestCase):
+    """Test the CompanyShareOptionFactor domain entity."""
+
+    def test_company_share_option_factor_creation(self):
+        """Test creating a CompanyShareOptionFactor."""
+        factor = CompanyShareOptionFactor(
+            name="Test Company Share Option Factor",
+            group="Company Share Option Factor",
+            subgroup="Test",
+            data_type="float",
+            source="calculated",
+            definition="Test factor for company share options",
+            factor_id=1
+        )
+
+        self.assertEqual(factor.name, "Test Company Share Option Factor")
+        self.assertEqual(factor.group, "Company Share Option Factor")
+        self.assertEqual(factor.subgroup, "Test")
+        self.assertEqual(factor.data_type, "float")
+        self.assertEqual(factor.source, "calculated")
+        self.assertEqual(factor.definition, "Test factor for company share options")
+        self.assertEqual(factor.factor_id, 1)
+
+
+class TestCompanyShareOptionPriceReturnFactor(unittest.TestCase):
+    """Test the CompanyShareOptionPriceReturnFactor domain entity."""
+
+    def test_company_share_option_price_return_factor_creation(self):
+        """Test creating a CompanyShareOptionPriceReturnFactor."""
+        factor = CompanyShareOptionPriceReturnFactor(factor_id=1)
+
+        self.assertEqual(factor.name, "Company Share Option Price Return")
+        self.assertEqual(factor.group, "Company Share Option Factor")
+        self.assertEqual(factor.subgroup, "Price Return")
+        self.assertEqual(factor.data_type, "float")
+        self.assertEqual(factor.source, "calculated")
+        self.assertTrue("price return" in factor.definition.lower())
+        self.assertEqual(factor.factor_id, 1)
+
+    def test_calculate_price_return(self):
+        """Test price return calculation."""
+        factor = CompanyShareOptionPriceReturnFactor()
+        
+        # Test normal price return calculation
+        current_price = 10.0
+        previous_price = 8.0
+        expected_return = 0.25  # (10 - 8) / 8 = 0.25 or 25%
+        
+        result = factor.calculate_price_return(current_price, previous_price)
+        self.assertAlmostEqual(result, expected_return, places=4)
+
+    def test_calculate_price_return_zero_previous_price(self):
+        """Test price return calculation with zero previous price."""
+        factor = CompanyShareOptionPriceReturnFactor()
+        
+        result = factor.calculate_price_return(10.0, 0.0)
+        self.assertIsNone(result)
+
+    def test_calculate_log_return(self):
+        """Test logarithmic return calculation."""
+        factor = CompanyShareOptionPriceReturnFactor()
+        
+        import math
+        current_price = 10.0
+        previous_price = 8.0
+        expected_log_return = math.log(10.0 / 8.0)
+        
+        result = factor.calculate_log_return(current_price, previous_price)
+        self.assertAlmostEqual(result, expected_log_return, places=4)
+
+    def test_calculate_sharpe_ratio(self):
+        """Test Sharpe ratio calculation."""
+        factor = CompanyShareOptionPriceReturnFactor()
+        
+        option_return = 0.15  # 15% return
+        risk_free_rate = 0.03  # 3% risk-free rate
+        return_volatility = 0.20  # 20% volatility
+        expected_sharpe = (0.15 - 0.03) / 0.20  # 0.6
+        
+        result = factor.calculate_sharpe_ratio(option_return, risk_free_rate, return_volatility)
+        self.assertAlmostEqual(result, expected_sharpe, places=4)
+
+
+class TestCompanyShareOptionInfrastructure(unittest.TestCase):
+    """Test infrastructure models and mappers."""
+
+    def test_company_share_option_model_creation(self):
+        """Test creating a CompanyShareOptionModel."""
+        model = CompanyShareOptionModel()
+        
+        # Test that the model can be instantiated
+        self.assertIsInstance(model, CompanyShareOptionModel)
+        self.assertEqual(model.__tablename__, 'company_share_options')
+
+    def test_company_share_option_mapper(self):
+        """Test CompanyShareOption mapper functionality."""
+        # Create domain entity
+        domain_entity = CompanyShareOption(
+            id=1,
+            name="Test Option",
+            symbol="TEST240315C100",
+            currency_id=1,
+            underlying_asset_id=100,
+            option_type="call",
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 3, 15)
+        )
+
+        # Convert to ORM
+        mapper = CompanyShareOptionMapper()
+        orm_model = mapper.to_orm(domain_entity)
+
+        # Verify ORM model
+        self.assertIsInstance(orm_model, CompanyShareOptionModel)
+        self.assertEqual(orm_model.id, 1)
+        self.assertEqual(orm_model.name, "Test Option")
+        self.assertEqual(orm_model.symbol, "TEST240315C100")
+
+        # Convert back to domain
+        converted_domain = mapper.to_domain(orm_model)
+        
+        # Verify round-trip conversion
+        self.assertEqual(converted_domain.id, domain_entity.id)
+        self.assertEqual(converted_domain.name, domain_entity.name)
+        self.assertEqual(converted_domain.symbol, domain_entity.symbol)
+
+    def test_factor_model_discriminator(self):
+        """Test factor model discriminators are properly set."""
+        factor_model = CompanyShareOptionFactorModel()
+        price_return_model = CompanyShareOptionPriceReturnFactorModel()
+        
+        # Check discriminators
+        self.assertEqual(factor_model.__mapper_args__['polymorphic_identity'], 'company_share_option_factor')
+        self.assertEqual(price_return_model.__mapper_args__['polymorphic_identity'], 'company_share_option_price_return_factor')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement complete DDD-compliant pipeline for CompanyShareOption entities:

**Domain Layer:**
- Add CompanyShareOptionPriceReturnFactor with comprehensive calculations
- Create port interface for repository contracts

**Infrastructure Layer:**
- Add CompanyShareOptionModel inheriting from OptionsModel
- Add factor models to SQLAlchemy hierarchy
- Create repositories for local database operations
- Add domain/ORM mappers for entity conversions
- Update model registry and repository factory integrations

**Testing:**
- Add comprehensive test suite covering domain, infrastructure, and mappings

Pipeline now ready to create CompanyShareOption and CompanyShareOptionPriceReturnFactor entities.

Fixes #457

Generated with [Claude Code](https://claude.ai/code)