### PR TITLE
fix: resolve SQLAlchemy relationship mapping inconsistency

### DIFF
--- a/src/infrastructure/models/finance/exchange.py
+++ b/src/infrastructure/models/finance/exchange.py
@@ -21,7 +21,7 @@ class ExchangeModel(Base):
     index_future_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.index_future_option.IndexFutureOptionModel", back_populates="exchange")
     company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option.CompanyShareOptionModel", back_populates="exchange")
     etf_share_portfolio_company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.etf_share_portfolio_company_share_option.ETFSharePortfolioCompanyShareOptionModel", back_populates="exchange")
-    portfolio_company_share_option = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option.PortfolioCompanyShareOptionModel", back_populates="exchange")
+    portfolio_company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option.PortfolioCompanyShareOptionModel", back_populates="exchange")
     etf_share_portfolio_company_shares = relationship("src.infrastructure.models.finance.financial_assets.etf_share_portfolio_company_share.ETFSharePortfolioCompanyShareModel", back_populates="exchange")
     
     


### PR DESCRIPTION
Fixes SQLAlchemy mapper initialization failures caused by relationship name inconsistency.

## Changes
- Fixed relationship name mismatch between ExchangeModel and PortfolioCompanyShareOptionModel
- Changed `portfolio_company_share_option` to `portfolio_company_share_options` in ExchangeModel
- Maintains consistency with plural naming convention used throughout the model

## Error Resolved
Mapper 'ExchangeModel' has no property 'portfolio_company_share_options'

Resolves #475

🤖 Generated with [Claude Code](https://claude.ai/code)