### PR TITLE
feat: add expiry parameter to CompanyShareOption entity

### DIFF
--- a/src/domain/entities/finance/financial_assets/derivatives/option/company_share_option.py
+++ b/src/domain/entities/finance/financial_assets/derivatives/option/company_share_option.py
@@ -23,11 +23,13 @@ class CompanyShareOption(Option):
             end_date: Optional[date] = None,
             strike_price: Optional[Decimal] = None, 
             multiplier: Optional[int] = None,
+            expiry: Optional[str] = None,
         ):
 
         super().__init__(id=id, currency_id=currency_id, underlying_asset_id=underlying_asset_id, name=name, symbol=symbol, start_date=start_date, end_date=end_date, option_type=option_type)
         self.strike_price = strike_price
         self.multiplier = multiplier  # Contract multiplier (e.g., 100 for SPX)
         self.exchange_id = exchange_id
+        self.expiry = expiry
     
        

--- a/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
@@ -22,6 +22,7 @@ class CompanyShareOptionModel(OptionsModel):
     # Index future option specific fields
     strike_price = Column(Numeric(precision=15, scale=6), nullable=True)
     multiplier = Column(Numeric(precision=10, scale=2), nullable=True, default=1.0)
+    expiry = Column(String(20), nullable=True)
     exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_share_options") 
     
     

--- a/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/derivatives/option/company_share_option_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/finance/financial_assets/derivatives/option/company_share_option_repository.py
@@ -283,7 +283,8 @@ class IBKRCompanyShareOptionRepository(IBKRFinancialAssetRepository, CompanyShar
                 exchange_id=exchange.id ,
                 option_type = option_type,
                 strike_price=Decimal(str(contract.strike)) if hasattr(contract, 'strike') and contract.strike else None,
-                multiplier=int(contract.multiplier) if hasattr(contract, 'multiplier') and contract.multiplier else 100
+                multiplier=int(contract.multiplier) if hasattr(contract, 'multiplier') and contract.multiplier else 100,
+                expiry=contract.lastTradeDateOrContractMonth if hasattr(contract, 'lastTradeDateOrContractMonth') and contract.lastTradeDateOrContractMonth else None
             )
         except Exception as e:
             print(f"Error converting IBKR option contract to domain entity: {e}_{os.path.abspath(__file__)}")

--- a/src/infrastructure/repositories/mappers/finance/financial_assets/company_share_option_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/financial_assets/company_share_option_mapper.py
@@ -25,9 +25,13 @@ class CompanyShareOptionMapper:
             symbol=getattr(orm_obj, 'symbol', None),
             currency_id=getattr(orm_obj, 'currency_id', None),
             underlying_asset_id=getattr(orm_obj, 'underlying_asset_id', None),
+            exchange_id=getattr(orm_obj, 'exchange_id', None),
             option_type=getattr(orm_obj, 'option_type', None),
             start_date=getattr(orm_obj, 'start_date', None),
-            end_date=getattr(orm_obj, 'end_date', None)
+            end_date=getattr(orm_obj, 'end_date', None),
+            strike_price=getattr(orm_obj, 'strike_price', None),
+            multiplier=getattr(orm_obj, 'multiplier', None),
+            expiry=getattr(orm_obj, 'expiry', None)
         )
         
         return domain_entity
@@ -50,6 +54,12 @@ class CompanyShareOptionMapper:
             orm_obj.underlying_asset_id = domain_obj.underlying_asset_id
         if hasattr(domain_obj, 'exchange_id'):
             orm_obj.exchange_id = domain_obj.exchange_id
+        if hasattr(domain_obj, 'strike_price'):
+            orm_obj.strike_price = domain_obj.strike_price
+        if hasattr(domain_obj, 'multiplier'):
+            orm_obj.multiplier = domain_obj.multiplier
+        if hasattr(domain_obj, 'expiry'):
+            orm_obj.expiry = domain_obj.expiry
         # Map optional financial asset attributes
         if hasattr(domain_obj, 'name'):
             orm_obj.name = domain_obj.name


### PR DESCRIPTION
Add expiry field to CompanyShareOption entity and all dependencies

## Changes
- Add expiry field to CompanyShareOption domain entity
- Update SQLAlchemy model to include expiry column
- Update IBKR repository to pass expiry from contract to entity
- Update mapper to handle expiry, strike_price, multiplier, and exchange_id fields

Fixes #485

Generated with [Claude Code](https://claude.ai/code)