### PR TITLE
feat: enhance portfolio registration to create main + sub-portfolios from config

### DIFF
--- a/src/application/managers/project_managers/market_making_SPX_call_spread_project/backtesting/base_project_algorithm.py
+++ b/src/application/managers/project_managers/market_making_SPX_call_spread_project/backtesting/base_project_algorithm.py
@@ -76,15 +76,11 @@ class Algorithm(QCAlgorithm):
         portfolio_config = self.config.get('Portfolio', {})
         self.spx_portfolio_name = portfolio_config.get('name', 'SPX_Call_Spread_Portfolio')
 
-        # Register the SPX trading portfolio with EntityService
+        # Register the SPX trading portfolio with EntityService using full config
         if self._entity_service:
-            initial_cash = portfolio_config.get('initial_cash', 1000000)
-            portfolio_type = portfolio_config.get('portfolio_type', 'BACKTEST')
-            
+            # Pass entire portfolio config to enable creation of main + sub-portfolios
             portfolio_entity = self.register_portfolio(
-                name=self.spx_portfolio_name,
-                initial_cash=initial_cash,
-                portfolio_type=portfolio_type
+                portfolio_config=portfolio_config
             )
             if portfolio_entity:
                 self.portfolio_entity = portfolio_entity

--- a/src/application/services/misbuffet/algorithm/base.py
+++ b/src/application/services/misbuffet/algorithm/base.py
@@ -787,19 +787,28 @@ class QCAlgorithm:
         """Access repository factory through EntityService."""
         return self._entity_service.repository_factory if self._entity_service else None
     
-    def register_portfolio(self, name: str, initial_cash: float = 100000.0, 
-                          portfolio_type: str = "BACKTEST") -> Optional[Any]:
+    def register_portfolio(self, portfolio_config: Dict[str, Any] = None, 
+                          name: str = None, initial_cash: float = None, 
+                          portfolio_type: str = None) -> Optional[Any]:
         """
         Register portfolio using unified portfolio management system.
         
-        This replaces dual portfolio tracking with a single system using domain entities.
+        Can accept either a portfolio_config dict (new enhanced way) or individual 
+        parameters (legacy compatibility).
+        
+        Args:
+            portfolio_config: Full portfolio configuration dict with sub-portfolios
+            name: Portfolio name (legacy)
+            initial_cash: Initial cash (legacy)
+            portfolio_type: Portfolio type (legacy)
         """
         if not self._unified_portfolio_manager:
             self.warning("No unified portfolio manager available")
             return None
         
-        # Use unified portfolio manager
-        portfolio = self._unified_portfolio_manager.register_portfolio(
+        # Use enhanced register_portfolio method that handles config dict
+        portfolio = self._unified_portfolio_manager.register_portfolio_with_config(
+            portfolio_config=portfolio_config,
             name=name,
             initial_cash=initial_cash,
             portfolio_type=portfolio_type
@@ -807,8 +816,9 @@ class QCAlgorithm:
         
         if portfolio:
             # Update QCAlgorithm's portfolio cash to sync with domain entity
-            self.portfolio.cash = initial_cash
-            self.portfolio.total_portfolio_value = initial_cash
+            cash_amount = initial_cash or (portfolio_config.get('initial_cash', 100000.0) if portfolio_config else 100000.0)
+            self.portfolio.cash = cash_amount
+            self.portfolio.total_portfolio_value = cash_amount
             
             # Store reference for legacy compatibility
             self._current_portfolio_entity = portfolio

--- a/src/application/services/misbuffet/algorithm/unified_portfolio_manager.py
+++ b/src/application/services/misbuffet/algorithm/unified_portfolio_manager.py
@@ -54,7 +54,7 @@ class UnifiedPortfolioManager:
         portfolio_type: str = "BACKTEST"
     ) -> Optional[Portfolio]:
         """
-        Register or retrieve a portfolio entity.
+        Register or retrieve a portfolio entity (legacy method).
         
         Args:
             name: Portfolio name
@@ -83,6 +83,101 @@ class UnifiedPortfolioManager:
         except Exception as e:
             if self.logger:
                 self.logger.error(f"❌ Portfolio registration failed: {e}")
+            return None
+
+    def register_portfolio_with_config(
+        self, 
+        portfolio_config: Optional[Dict[str, Any]] = None,
+        name: str = None,
+        initial_cash: float = None,
+        portfolio_type: str = None
+    ) -> Optional[Portfolio]:
+        """
+        Enhanced portfolio registration that creates main portfolio + sub-portfolios from config.
+        
+        Args:
+            portfolio_config: Full portfolio configuration dict with sub-portfolios
+            name: Portfolio name (fallback)
+            initial_cash: Initial cash (fallback)
+            portfolio_type: Portfolio type (fallback)
+            
+        Returns:
+            Main portfolio entity or None if registration failed
+        """
+        try:
+            # Determine main portfolio parameters
+            if portfolio_config:
+                main_name = portfolio_config.get('name', name or 'Default_Portfolio')
+                main_cash = portfolio_config.get('initial_cash', initial_cash or 100000.0)
+                main_type = portfolio_config.get('portfolio_type', portfolio_type or 'BACKTEST')
+                main_currency = portfolio_config.get('currency_code', 'USD')
+                sub_portfolios_config = portfolio_config.get('sub_portfolios', [])
+            else:
+                # Fallback to individual parameters
+                main_name = name or 'Default_Portfolio'
+                main_cash = initial_cash or 100000.0
+                main_type = portfolio_type or 'BACKTEST'
+                main_currency = 'USD'
+                sub_portfolios_config = []
+            
+            # Create main portfolio
+            main_portfolio = self.portfolio_repo._create_or_get(
+                name=main_name,
+                portfolio_type=main_type,
+                initial_cash=main_cash,
+                currency_code=main_currency
+            )
+            
+            if not main_portfolio:
+                if self.logger:
+                    self.logger.error(f"❌ Failed to create main portfolio: {main_name}")
+                return None
+            
+            self._current_portfolio_entity = main_portfolio
+            
+            if self.logger:
+                self.logger.info(f"✅ Main portfolio created: {main_portfolio.name} (ID: {main_portfolio.id})")
+            
+            # Create sub-portfolios
+            created_sub_portfolios = []
+            for sub_config in sub_portfolios_config:
+                try:
+                    sub_name = sub_config.get('name', f"{main_name}_Sub")
+                    sub_cash = sub_config.get('initial_cash', main_cash)
+                    sub_type = sub_config.get('portfolio_type', main_type)
+                    sub_currency = sub_config.get('currency_code', main_currency)
+                    sub_portfolio_type = sub_config.get('type', 'general')  # company_share, derivative, etc.
+                    
+                    # Create sub-portfolio
+                    sub_portfolio = self.portfolio_repo._create_or_get(
+                        name=sub_name,
+                        portfolio_type=sub_type,
+                        initial_cash=sub_cash,
+                        currency_code=sub_currency,
+                        parent_portfolio_id=main_portfolio.id  # Link to main portfolio
+                    )
+                    
+                    if sub_portfolio:
+                        created_sub_portfolios.append(sub_portfolio)
+                        if self.logger:
+                            self.logger.info(f"✅ Sub-portfolio created: {sub_portfolio.name} (Type: {sub_portfolio_type})")
+                    else:
+                        if self.logger:
+                            self.logger.warning(f"⚠️ Failed to create sub-portfolio: {sub_name}")
+                            
+                except Exception as sub_e:
+                    if self.logger:
+                        self.logger.error(f"❌ Error creating sub-portfolio {sub_config.get('name', 'unknown')}: {sub_e}")
+                    continue
+            
+            if self.logger:
+                self.logger.info(f"✅ Portfolio registration complete: {main_portfolio.name} + {len(created_sub_portfolios)} sub-portfolios")
+            
+            return main_portfolio
+            
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"❌ Enhanced portfolio registration failed: {e}")
             return None
 
     def get_current_portfolio(self) -> Optional[Portfolio]:


### PR DESCRIPTION
Enhanced portfolio registration to use full Portfolio config dict and create hierarchical portfolio structure

- Modified algorithm to pass full Portfolio config instead of individual parameters
- Enhanced UnifiedPortfolioManager to create main + sub-portfolios from config
- Creates 3 portfolios: main, company share, and option portfolios
- Uses all config values ($1M initial cash, USD currency, BACKTEST type)
- Maintains backward compatibility with legacy calls

Resolves #499

🤖 Generated with [Claude Code](https://claude.ai/code)