### PR TITLE
fix: add missing PortfolioDerivativeHoldingModel SQLAlchemy model

### DIFF
--- a/src/infrastructure/models/__init__.py
+++ b/src/infrastructure/models/__init__.py
@@ -83,6 +83,8 @@ from src.infrastructure.models.finance.holding.holding import HoldingModel
 from src.infrastructure.models.finance.holding.portfolio_holding import PortfolioHoldingsModel
 from src.infrastructure.models.finance.holding.security_holding import SecurityHoldingModel
 from src.infrastructure.models.finance.holding.portfolio_company_share_holding import PortfolioCompanyShareHoldingModel
+from src.infrastructure.models.finance.holding.portfolio_company_share_option_holding import PortfolioCompanyShareOptionHoldingModel
+from src.infrastructure.models.finance.holding.derivative.portfolio_derivative_holding import PortfolioDerivativeHoldingModel
 
 # Account, Order, and Transaction models
 from src.infrastructure.models.finance.account import AccountModel
@@ -112,7 +114,7 @@ def ensure_models_registered():
         'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
         'ShareModel', 'CompanyShareModel', 'ETFShareModel', 'ETFSharePortfolioCompanyShareModel', 
         'PortfolioModel','PortfolioDerivativeModel', 'PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 
-        'HoldingModel', 'IndexFutureOptionModel', 'IndexFutureModel', 'OptionsModel', 'CompanyShareOptionModel',
+        'HoldingModel', 'PortfolioDerivativeHoldingModel', 'PortfolioCompanyShareOptionHoldingModel', 'IndexFutureOptionModel', 'IndexFutureModel', 'OptionsModel', 'CompanyShareOptionModel',
         'ETFSharePortfolioCompanyShareOptionModel', 'AccountModel', 'OrderModel', 'TransactionModel'
     }
     
@@ -147,7 +149,7 @@ __all__ = [
     'SwapModel',  'SwapLegModel',
     'PortfolioModel','PortfolioDerivativeModel','PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 'SecurityHoldingModel', 
     'MarketDataModel', 'InstrumentModel',
-    'HoldingModel', 'PortfolioHoldingsModel', 'PortfolioCompanyShareHoldingModel','PositionModel','FactorModel','FactorValueModel','FactorDependencyModel',
+    'HoldingModel', 'PortfolioHoldingsModel', 'PortfolioCompanyShareHoldingModel', 'PortfolioCompanyShareOptionHoldingModel', 'PortfolioDerivativeHoldingModel','PositionModel','FactorModel','FactorValueModel','FactorDependencyModel',
     'AccountModel', 'OrderModel', 'TransactionModel',
     'ensure_models_registered'
 ]

--- a/src/infrastructure/models/finance/financial_assets/derivative/derivatives.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/derivatives.py
@@ -25,6 +25,13 @@ class DerivativeModel(FinancialAssetModel):
         back_populates="underlying_derivatives"
     )
     currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel",foreign_keys=[currency_id], back_populates="derivatives")
+    
+    # ONE derivative → MANY portfolio_derivative_holdings
+    portfolio_derivative_holdings = relationship(
+        "src.infrastructure.models.finance.holding.derivative.portfolio_derivative_holding.PortfolioDerivativeHoldingModel",
+        back_populates="derivative"
+    )
+    
     __mapper_args__ = {
     "polymorphic_identity": "derivative",
     "inherit_condition": id == FinancialAssetModel.id,  # 🔥 REQUIRED

--- a/src/infrastructure/models/finance/holding/derivative/__init__.py
+++ b/src/infrastructure/models/finance/holding/derivative/__init__.py
@@ -1,0 +1,1 @@
+# Derivative holding models

--- a/src/infrastructure/models/finance/holding/derivative/portfolio_derivative_holding.py
+++ b/src/infrastructure/models/finance/holding/derivative/portfolio_derivative_holding.py
@@ -1,0 +1,34 @@
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+
+from src.infrastructure.models.finance.holding.portfolio_holding import PortfolioHoldingsModel
+
+
+class PortfolioDerivativeHoldingModel(PortfolioHoldingsModel):
+    """
+    SQLAlchemy model for portfolio derivative holding.
+    Maps to domain.entities.finance.holding.derivative.portfolio_derivative_holding.PortfolioDerivativeHolding
+    """
+    __tablename__ = 'portfolio_derivative_holdings'
+    id = Column(Integer, ForeignKey("portfolio_holdings.id"), primary_key=True)
+
+    # Foreign key to portfolio derivative
+    portfolio_derivative_id = Column(Integer, ForeignKey("portfolio_derivatives.id"), nullable=False)
+
+    # Foreign key to derivative asset
+    derivative_id = Column(Integer, ForeignKey("derivatives.id"), nullable=False)
+
+    # Relationships
+    portfolio_derivative = relationship(
+        "src.infrastructure.models.finance.portfolio.portfolio_derivative.PortfolioDerivativeModel",
+        back_populates="portfolio_derivative_holdings"
+    )
+
+    derivative = relationship(
+        "src.infrastructure.models.finance.financial_assets.derivative.derivative.DerivativeModel",
+        back_populates="portfolio_derivative_holdings"
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "portfolio_derivative_holding",
+    }


### PR DESCRIPTION
Fixed SQLAlchemy mapper initialization error by creating missing model

- Created PortfolioDerivativeHoldingModel in derivative holding directory
- Added proper relationships between portfolio, holding, and derivative models
- Registered model in models/__init__.py for SQLAlchemy string relationship resolution
- Resolves InvalidRequestError when creating portfolio derivative holdings

Resolves #499

Generated with [Claude Code](https://claude.ai/code)