### PR TITLE
fix: correct DerivativeModel import path in PortfolioDerivativeHoldingModel

### DIFF
--- a/src/infrastructure/models/finance/holding/derivative/portfolio_derivative_holding.py
+++ b/src/infrastructure/models/finance/holding/derivative/portfolio_derivative_holding.py
@@ -25,7 +25,7 @@ class PortfolioDerivativeHoldingModel(PortfolioHoldingsModel):
     )
 
     derivative = relationship(
-        "src.infrastructure.models.finance.financial_assets.derivative.derivative.DerivativeModel",
+        "src.infrastructure.models.finance.financial_assets.derivative.derivatives.DerivativeModel",
         back_populates="portfolio_derivative_holdings"
     )
 


### PR DESCRIPTION
Fixes SQLAlchemy mapping error preventing portfolio creation.

**Root Cause:**
The PortfolioDerivativeHoldingModel was trying to import DerivativeModel from an incorrect path:
- Old: `src.infrastructure.models.finance.financial_assets.derivative.derivative.DerivativeModel`
- New: `src.infrastructure.models.finance.financial_assets.derivative.derivatives.DerivativeModel`

**Changes:**
- Fixed relationship import path in portfolio_derivative_holding.py
- DerivativeModel is defined in derivatives.py, not derivative.py

Resolves issue #510

Generated with [Claude Code](https://claude.ai/code)