### PR TITLE
fix: resolve SQLAlchemy mapping conflicts and missing relationships

### DIFF
--- a/src/infrastructure/models/__init__.py
+++ b/src/infrastructure/models/__init__.py
@@ -20,7 +20,7 @@ class ModelBase(DeclarativeBase):
 
 # Core geographical and organizational models (no dependencies)
 # Geographic models
-from src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option import PortfolioCompanyShareOptionModel
+from src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option import PortfolioCompanyShareOptionDerivativeModel
 from src.infrastructure.models.continent import ContinentModel
 from src.infrastructure.models.country import CountryModel
 from src.infrastructure.models.industry import IndustryModel
@@ -56,7 +56,7 @@ from src.infrastructure.models.finance.financial_assets.bond import BondModel
 from src.infrastructure.models.finance.financial_assets.derivative.option.options import OptionsModel
 from src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option import CompanyShareOptionModel
 from src.infrastructure.models.finance.financial_assets.derivative.option.index_future_option import IndexFutureOptionModel
-from src.infrastructure.models.finance.financial_assets.derivative.option.etf_share_portfolio_company_share_option import ETFSharePortfolioCompanyShareOptionModel
+from src.infrastructure.models.finance.financial_assets.derivative.option.etf_share_portfolio_company_share_option import ETFSharePortfolioCompanyShareOptionDerivativeModel
 from src.infrastructure.models.finance.financial_assets.derivative.future.future import FutureModel
 from src.infrastructure.models.finance.financial_assets.derivative.future.index_future import IndexFutureModel
 from src.infrastructure.models.finance.financial_assets.derivative.derivatives import DerivativeModel
@@ -92,7 +92,7 @@ from src.infrastructure.models.finance.order.order import OrderModel
 from src.infrastructure.models.finance.transaction.transaction import TransactionModel
 
 # Portfolio options
-PortfolioCompanyShareOptionModel
+PortfolioCompanyShareOptionDerivativeModel
 
 
 
@@ -113,9 +113,9 @@ def ensure_models_registered():
         'CountryModel', 'IndustryModel', 'SectorModel', 'ExchangeModel', 'CompanyModel',
         'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
         'ShareModel', 'CompanyShareModel', 'ETFShareModel', 'ETFSharePortfolioCompanyShareModel', 
-        'PortfolioModel','PortfolioDerivativeModel', 'PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 
+        'PortfolioModel','PortfolioDerivativeModel', 'PortfolioCompanyShareModel','PortfolioCompanyShareOptionDerivativeModel', 
         'HoldingModel', 'PortfolioDerivativeHoldingModel', 'PortfolioCompanyShareOptionHoldingModel', 'IndexFutureOptionModel', 'IndexFutureModel', 'OptionsModel', 'CompanyShareOptionModel',
-        'ETFSharePortfolioCompanyShareOptionModel', 'AccountModel', 'OrderModel', 'TransactionModel'
+        'ETFSharePortfolioCompanyShareOptionDerivativeModel', 'AccountModel', 'OrderModel', 'TransactionModel'
     }
     
     missing = required_models - set(registered)
@@ -143,11 +143,11 @@ __all__ = [
     'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
     'FinancialAssetModel', 'CurrencyModel', 'CashModel', 'CommodityModel', 'SecurityModel', 'EquityModel',
     'ShareModel', 'CompanyShareModel', 'ETFShareModel', 'ETFSharePortfolioCompanyShareModel',
-    'BondModel', 'OptionsModel', 'CompanyShareOptionModel', 'ETFSharePortfolioCompanyShareOptionModel', 
+    'BondModel', 'OptionsModel', 'CompanyShareOptionModel', 'ETFSharePortfolioCompanyShareOptionDerivativeModel', 
     'IndexFutureOptionModel', 'FutureModel', 'IndexFutureModel','DerivativeModel',
     'ForwardContractModel', 
     'SwapModel',  'SwapLegModel',
-    'PortfolioModel','PortfolioDerivativeModel','PortfolioCompanyShareModel','PortfolioCompanyShareOptionModel', 'SecurityHoldingModel', 
+    'PortfolioModel','PortfolioDerivativeModel','PortfolioCompanyShareModel','PortfolioCompanyShareOptionDerivativeModel', 'SecurityHoldingModel', 
     'MarketDataModel', 'InstrumentModel',
     'HoldingModel', 'PortfolioHoldingsModel', 'PortfolioCompanyShareHoldingModel', 'PortfolioCompanyShareOptionHoldingModel', 'PortfolioDerivativeHoldingModel','PositionModel','FactorModel','FactorValueModel','FactorDependencyModel',
     'AccountModel', 'OrderModel', 'TransactionModel',

--- a/src/infrastructure/models/finance/exchange.py
+++ b/src/infrastructure/models/finance/exchange.py
@@ -21,7 +21,7 @@ class ExchangeModel(Base):
     index_future_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.index_future_option.IndexFutureOptionModel", back_populates="exchange")
     company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option.CompanyShareOptionModel", back_populates="exchange")
     etf_share_portfolio_company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.etf_share_portfolio_company_share_option.ETFSharePortfolioCompanyShareOptionModel", back_populates="exchange")
-    portfolio_company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option.PortfolioCompanyShareOptionModel", back_populates="exchange")
+    portfolio_company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option.PortfolioCompanyShareOptionDerivativeModel", back_populates="exchange")
     etf_share_portfolio_company_shares = relationship("src.infrastructure.models.finance.financial_assets.etf_share_portfolio_company_share.ETFSharePortfolioCompanyShareModel", back_populates="exchange")
     
     

--- a/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
@@ -23,7 +23,8 @@ class CompanyShareOptionModel(OptionsModel):
     strike_price = Column(Numeric(precision=15, scale=6), nullable=True)
     multiplier = Column(Numeric(precision=10, scale=2), nullable=True, default=1.0)
     expiry = Column(String(20), nullable=True)
-    exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_share_options") 
+    exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_share_options")
+    portfolio_company_share_option_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_company_share_option_holding.PortfolioCompanyShareOptionHoldingModel", back_populates="company_share_option") 
     
     
     __mapper_args__ = {

--- a/src/infrastructure/models/finance/financial_assets/derivative/option/portfolio_company_share_option.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/option/portfolio_company_share_option.py
@@ -2,12 +2,12 @@ from sqlalchemy import Column, Integer, String, Numeric, ForeignKey
 from src.infrastructure.models.finance.financial_assets.derivative.option.options import OptionsModel
 from sqlalchemy.orm import relationship
 
-class PortfolioCompanyShareOptionModel(OptionsModel):
+class PortfolioCompanyShareOptionDerivativeModel(OptionsModel):
     """
     SQLAlchemy ORM model for Index Future Options.
     Completely separate from src.domain entity to avoid metaclass conflicts.
     """
-    __tablename__ = 'portfolio_company_share_options'
+    __tablename__ = 'portfolio_company_share_option_derivatives'
 
     id = Column(Integer, ForeignKey("options.id"), primary_key=True)
     exchange_id = Column(Integer, ForeignKey('exchanges.id'), nullable=False)

--- a/src/infrastructure/repositories/local_repo/finance/financial_assets/derivatives/option/portfolio_company_share_option_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/financial_assets/derivatives/option/portfolio_company_share_option_repository.py
@@ -6,7 +6,7 @@ from datetime import date
 
 from sqlalchemy.orm import Session
 
-from src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option import PortfolioCompanyShareOptionModel
+from src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option import PortfolioCompanyShareOptionDerivativeModel
 from src.domain.ports.finance.financial_assets.derivatives.option.portfolio_company_share_option_port import PortfolioCompanyShareOptionPort
 from src.infrastructure.repositories.local_repo.finance.financial_assets.financial_asset_repository import FinancialAssetRepository
 from src.infrastructure.repositories.mappers.finance.financial_assets.portfolio_company_share_option_mapper import PortfolioCompanyShareOptionMapper
@@ -23,7 +23,7 @@ class PortfolioCompanyShareOptionRepository(FinancialAssetRepository, PortfolioC
     @property
     def model_class(self):
         """Return the SQLAlchemy model class for PortfolioCompanyShareOption."""
-        return PortfolioCompanyShareOptionModel
+        return PortfolioCompanyShareOptionDerivativeModel
     
     @property
     def entity_class(self):
@@ -32,35 +32,35 @@ class PortfolioCompanyShareOptionRepository(FinancialAssetRepository, PortfolioC
 
     def get_by_id(self, option_id: int) -> Optional[PortfolioCompanyShareOptionEntity]:
         """Get an option by ID"""
-        model = self.session.query(PortfolioCompanyShareOptionModel).filter_by(id=option_id).first()
+        model = self.session.query(PortfolioCompanyShareOptionDerivativeModel).filter_by(id=option_id).first()
         return self.mapper.to_entity(model) if model else None
 
     def get_all(self) -> List[PortfolioCompanyShareOptionEntity]:
         """Get all options"""
-        models = self.session.query(PortfolioCompanyShareOptionModel).all()
+        models = self.session.query(PortfolioCompanyShareOptionDerivativeModel).all()
         return [self.mapper.to_entity(model) for model in models]
 
     def get_by_underlying_id(self, underlying_id: int) -> List[PortfolioCompanyShareOptionEntity]:
         """Get all options for a specific underlying asset"""
-        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(underlying_id=underlying_id).all()
+        models = self.session.query(PortfolioCompanyShareOptionDerivativeModel).filter_by(underlying_id=underlying_id).all()
         return [self.mapper.to_entity(model) for model in models]
 
     def get_by_company_id(self, company_id: int) -> List[PortfolioCompanyShareOptionEntity]:
         """Get all options for a specific company"""
-        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(company_id=company_id).all()
+        models = self.session.query(PortfolioCompanyShareOptionDerivativeModel).filter_by(company_id=company_id).all()
         return [self.mapper.to_entity(model) for model in models]
 
     def get_by_expiration_date(self, expiration_date: date) -> List[PortfolioCompanyShareOptionEntity]:
         """Get all options expiring on a specific date"""
-        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(expiration_date=expiration_date).all()
+        models = self.session.query(PortfolioCompanyShareOptionDerivativeModel).filter_by(expiration_date=expiration_date).all()
         return [self.mapper.to_entity(model) for model in models]
 
     def get_active_options(self, company_id: int = None) -> List[PortfolioCompanyShareOptionEntity]:
         """Get active options (no end_date or end_date in future)"""
         from datetime import datetime
-        query = self.session.query(PortfolioCompanyShareOptionModel).filter(
-            (PortfolioCompanyShareOptionModel.end_date.is_(None)) | 
-            (PortfolioCompanyShareOptionModel.end_date > date.today())
+        query = self.session.query(PortfolioCompanyShareOptionDerivativeModel).filter(
+            (PortfolioCompanyShareOptionDerivativeModel.end_date.is_(None)) | 
+            (PortfolioCompanyShareOptionDerivativeModel.end_date > date.today())
         )
         if company_id:
             query = query.filter_by(company_id=company_id)
@@ -70,7 +70,7 @@ class PortfolioCompanyShareOptionRepository(FinancialAssetRepository, PortfolioC
 
     def get_by_option_type(self, option_type: str) -> List[PortfolioCompanyShareOptionEntity]:
         """Get options by type (CALL or PUT)"""
-        models = self.session.query(PortfolioCompanyShareOptionModel).filter_by(option_type=option_type).all()
+        models = self.session.query(PortfolioCompanyShareOptionDerivativeModel).filter_by(option_type=option_type).all()
         return [self.mapper.to_entity(model) for model in models]
 
     def save(self, option: PortfolioCompanyShareOptionEntity) -> PortfolioCompanyShareOptionEntity:
@@ -83,7 +83,7 @@ class PortfolioCompanyShareOptionRepository(FinancialAssetRepository, PortfolioC
 
     def delete(self, option_id: int) -> bool:
         """Delete an option by ID"""
-        model = self.session.query(PortfolioCompanyShareOptionModel).filter_by(id=option_id).first()
+        model = self.session.query(PortfolioCompanyShareOptionDerivativeModel).filter_by(id=option_id).first()
         if model:
             self.session.delete(model)
             self.session.commit()

--- a/src/infrastructure/repositories/mappers/finance/financial_assets/portfolio_company_share_option_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/financial_assets/portfolio_company_share_option_mapper.py
@@ -3,7 +3,7 @@ Mapper for converting between portfolio company share option domain entities and
 """
 from typing import Optional
 
-from src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option import PortfolioCompanyShareOptionModel
+from src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option import PortfolioCompanyShareOptionDerivativeModel
 from src.domain.entities.finance.financial_assets.derivatives.option.portfolio_company_share_option import PortfolioCompanyShareOption
 
 
@@ -11,8 +11,8 @@ from src.domain.entities.finance.financial_assets.derivatives.option.portfolio_c
 class PortfolioCompanyShareOptionMapper:
     """Mapper for converting between option entities and models"""
 
-    def to_entity(self, model: Optional[PortfolioCompanyShareOptionModel]) -> Optional[PortfolioCompanyShareOptionModel]:
-        """Convert PortfolioCompanyShareOptionModel to PortfolioCompanyShareOption entity"""
+    def to_entity(self, model: Optional[PortfolioCompanyShareOptionDerivativeModel]) -> Optional[PortfolioCompanyShareOptionDerivativeModel]:
+        """Convert PortfolioCompanyShareOptionDerivativeModel to PortfolioCompanyShareOption entity"""
         if not model:
             return None
 
@@ -28,7 +28,7 @@ class PortfolioCompanyShareOptionMapper:
         # Convert string to OptionType enum
         option_type = model.option_type
 
-        return PortfolioCompanyShareOptionModel(
+        return PortfolioCompanyShareOptionDerivativeModel(
             id=model.id,
             underlying=underlying,
             expiration_date=model.expiration_date,
@@ -37,9 +37,9 @@ class PortfolioCompanyShareOptionMapper:
             end_date=model.end_date
         )
 
-    def to_model(self, entity: PortfolioCompanyShareOptionModel) -> PortfolioCompanyShareOptionModel:
-        """Convert PortfolioCompanyShareOption entity to PortfolioCompanyShareOptionModel"""
-        return PortfolioCompanyShareOptionModel(
+    def to_model(self, entity: PortfolioCompanyShareOptionDerivativeModel) -> PortfolioCompanyShareOptionDerivativeModel:
+        """Convert PortfolioCompanyShareOption entity to PortfolioCompanyShareOptionDerivativeModel"""
+        return PortfolioCompanyShareOptionDerivativeModel(
             id=entity.id,
             underlying_id=entity.underlying.id,
             company_id=1,  # Default - not tracked at entity level


### PR DESCRIPTION
Resolves SQLAlchemy mapping errors preventing portfolio creation.

**Root Cause:**
Multiple related issues causing mapping conflicts:
1. Two classes named `PortfolioCompanyShareOptionModel` with same table name
2. Missing back-reference relationships in option models

**Changes:**
- Renamed derivative model class to `PortfolioCompanyShareOptionDerivativeModel`
- Changed derivative table name to `portfolio_company_share_option_derivatives`
- Updated all references across repository, mappers, and imports
- Added missing back-reference relationship in `CompanyShareOptionModel`

Resolves issue #510

🤖 Generated with [Claude Code](https://claude.ai/code)