### PR TITLE
fix: resolve entity name change import issues and inconsistencies

### DIFF
--- a/src/domain/ports/finance/portfolio/company_share_option_portfolio_port.py
+++ b/src/domain/ports/finance/portfolio/company_share_option_portfolio_port.py
@@ -1,8 +1,8 @@
 from typing import List, Optional
-from domain.entities.finance.portfolio.company_share_option_portfolio import CompanyShareOptionPortfolio
+from src.domain.entities.finance.portfolio.company_share_option_portfolio import CompanyShareOptionPortfolio
 
 
-class CompanyShareOptionPortPortfolio:
+class CompanyShareOptionPortfolioPort:
 
     def get_by_id(self, id: int) -> Optional[CompanyShareOptionPortfolio]:
         pass

--- a/src/domain/ports/finance/portfolio/company_share_portfolio_port.py
+++ b/src/domain/ports/finance/portfolio/company_share_portfolio_port.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
-from domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio
+from src.domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio
 
 
 class CompanySharePortfolioPort(ABC):

--- a/src/domain/ports/finance/portfolio/derivative_portfolio_port.py
+++ b/src/domain/ports/finance/portfolio/derivative_portfolio_port.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from domain.entities.finance.portfolio.derivative_portfolio import DerivativePortfolio
+from src.domain.entities.finance.portfolio.derivative_portfolio import DerivativePortfolio
 
 
 class DerivativePortfolioPort:

--- a/src/infrastructure/models/finance/portfolio/portfolio_company_share_option.py
+++ b/src/infrastructure/models/finance/portfolio/portfolio_company_share_option.py
@@ -7,7 +7,7 @@ from src.infrastructure.models.finance.portfolio.portfolio import PortfolioModel
 class CompanyShareOptionPortfolioModel(PortfolioModel):
     """
     SQLAlchemy model for portfolio company share option.
-    Maps to domain.entities.finance.portfolio.portfolio_company_share_option.PortfolioCompanyShareOption
+    Maps to domain.entities.finance.portfolio.company_share_option_portfolio.CompanyShareOptionPortfolio
     """
     __tablename__ = 'portfolio_company_share_options'
     id = Column(Integer, ForeignKey("portfolios.id"), primary_key=True)

--- a/src/infrastructure/models/finance/portfolio/portfolio_derivative.py
+++ b/src/infrastructure/models/finance/portfolio/portfolio_derivative.py
@@ -7,7 +7,7 @@ from src.infrastructure.models.finance.portfolio.portfolio import PortfolioModel
 class DerivativePortfolioModel(PortfolioModel):
     """
     SQLAlchemy model for portfolio derivative.
-    Maps to domain.entities.finance.portfolio.portfolio_derivative.PortfolioDerivative
+    Maps to domain.entities.finance.portfolio.derivative_portfolio.DerivativePortfolio
     """
     __tablename__ = 'portfolio_derivatives'
     id = Column(Integer, ForeignKey("portfolios.id"), primary_key=True)

--- a/src/infrastructure/repositories/local_repo/finance/portfolio/company_share_option_portfolio_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/portfolio/company_share_option_portfolio_repository.py
@@ -1,12 +1,12 @@
 from sqlalchemy.orm import Session
 from typing import Optional, List
 from datetime import datetime, date
-from domain.entities.finance.portfolio.company_share_option_portfolio import CompanyShareOptionPortfolio
-from domain.ports.finance.portfolio.company_share_option_portfolio_port import CompanyShareOptionPortPortfolio
+from src.domain.entities.finance.portfolio.company_share_option_portfolio import CompanyShareOptionPortfolio
+from src.domain.ports.finance.portfolio.company_share_option_portfolio_port import CompanyShareOptionPortfolioPort
 from src.infrastructure.repositories.mappers.finance.portfolio.portfolio_company_share_option_mapper import CompanyShareOptionPortfolioMapper
 
 
-class CompanyShareOptionPortfolioRepository(CompanyShareOptionPortPortfolio):
+class CompanyShareOptionPortfolioRepository(CompanyShareOptionPortfolioPort):
 
     def __init__(self, session: Session, factory=None):
         self.session = session

--- a/src/infrastructure/repositories/local_repo/finance/portfolio/company_share_portfolio_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/portfolio/company_share_portfolio_repository.py
@@ -2,9 +2,9 @@ from sqlalchemy.orm import Session
 from typing import Optional, List
 from datetime import datetime, date
 from src.infrastructure.models.finance.portfolio.portfolio_company_share import CompanySharePortfolioModel
-from domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio
+from src.domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio
 from src.infrastructure.repositories.mappers.finance.portfolio.portfolio_company_share_mapper import CompanySharePortfolioMapper
-from domain.ports.finance.portfolio.company_share_portfolio_port import CompanySharePortfolioPort
+from src.domain.ports.finance.portfolio.company_share_portfolio_port import CompanySharePortfolioPort
 
 
 class CompanySharePortfolioRepository(CompanySharePortfolioPort):

--- a/src/infrastructure/repositories/local_repo/finance/portfolio/derivative_portfolio_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/portfolio/derivative_portfolio_repository.py
@@ -1,8 +1,8 @@
 from sqlalchemy.orm import Session
 from typing import Optional, List
 from datetime import datetime, date
-from domain.entities.finance.portfolio.derivative_portfolio import DerivativePortfolio
-from domain.ports.finance.portfolio.derivative_portfolio_port import DerivativePortfolioPort
+from src.domain.entities.finance.portfolio.derivative_portfolio import DerivativePortfolio
+from src.domain.ports.finance.portfolio.derivative_portfolio_port import DerivativePortfolioPort
 from src.infrastructure.repositories.mappers.finance.portfolio.portfolio_derivative_mapper import DerivativePortfolioMapper
 
 

--- a/src/infrastructure/repositories/mappers/finance/portfolio/portfolio_company_share_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/portfolio/portfolio_company_share_mapper.py
@@ -6,7 +6,7 @@ Converts between domain entities and ORM models to avoid metaclass conflicts.
 from typing import Optional
 from datetime import datetime
 
-from domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio as DomainPortfolioCompanyShare
+from src.domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio as DomainPortfolioCompanyShare
 from src.infrastructure.models.finance.portfolio.portfolio_company_share import CompanySharePortfolioModel as ORMPortfolioCompanyShare
 
 

--- a/src/infrastructure/repositories/mappers/finance/portfolio/portfolio_company_share_option_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/portfolio/portfolio_company_share_option_mapper.py
@@ -6,7 +6,7 @@ Converts between domain entities and ORM models to avoid metaclass conflicts.
 from typing import Optional
 from datetime import datetime
 
-from domain.entities.finance.portfolio.company_share_option_portfolio import CompanyShareOptionPortfolio as DomainPortfolioCompanyShareOption
+from src.domain.entities.finance.portfolio.company_share_option_portfolio import CompanyShareOptionPortfolio as DomainPortfolioCompanyShareOption
 from src.infrastructure.models.finance.portfolio.portfolio_company_share_option import CompanyShareOptionPortfolioModel as ORMPortfolioCompanyShareOption
 
 

--- a/src/infrastructure/repositories/mappers/finance/portfolio/portfolio_derivative_mapper.py
+++ b/src/infrastructure/repositories/mappers/finance/portfolio/portfolio_derivative_mapper.py
@@ -5,7 +5,7 @@ Converts between domain entities and ORM models to avoid metaclass conflicts.
 
 from typing import Optional
 
-from domain.entities.finance.portfolio.derivative_portfolio import DerivativePortfolio as DomainPortfolioDerivative
+from src.domain.entities.finance.portfolio.derivative_portfolio import DerivativePortfolio as DomainPortfolioDerivative
 from src.infrastructure.models.finance.portfolio.portfolio_derivative import DerivativePortfolioModel as ORMPortfolioDerivative
 
 

--- a/src/infrastructure/repositories/repository_factory.py
+++ b/src/infrastructure/repositories/repository_factory.py
@@ -19,9 +19,9 @@ from src.infrastructure.repositories.local_repo.geographic.sector_repository imp
 from src.infrastructure.repositories.local_repo.geographic.industry_repository import IndustryRepository
 from src.infrastructure.repositories.local_repo.finance.position_repository import PositionRepository
 from src.infrastructure.repositories.local_repo.finance.portfolio_repository import PortfolioRepository
-from infrastructure.repositories.local_repo.finance.portfolio.company_share_portfolio_repository import CompanySharePortfolioRepository
-from infrastructure.repositories.local_repo.finance.portfolio.company_share_option_portfolio_repository import CompanyShareOptionPortfolioRepository
-from infrastructure.repositories.local_repo.finance.portfolio.derivative_portfolio_repository import DerivativePortfolioRepository
+from src.infrastructure.repositories.local_repo.finance.portfolio.company_share_portfolio_repository import CompanySharePortfolioRepository
+from src.infrastructure.repositories.local_repo.finance.portfolio.company_share_option_portfolio_repository import CompanyShareOptionPortfolioRepository
+from src.infrastructure.repositories.local_repo.finance.portfolio.derivative_portfolio_repository import DerivativePortfolioRepository
 from src.infrastructure.repositories.local_repo.finance.company_repository import CompanyRepository
 from src.infrastructure.repositories.local_repo.finance.holding.holding_repository import HoldingRepository
 from src.infrastructure.repositories.local_repo.finance.holding.portfolio_holding_repository import PortfolioHoldingRepository
@@ -321,9 +321,6 @@ class RepositoryFactory:
                 'portfolio': PortfolioRepository(self.session, factory=self),
                 'company': CompanyRepository(self.session, factory=self),
 
-                'portfolio_company_share': CompanySharePortfolioRepository(self.session, factory=self),
-                'portfolio_company_share_option': CompanyShareOptionPortfolioRepository(self.session, factory=self),
-                'portfolio_derivative': DerivativePortfolioRepository(self.session, factory=self),
                 # Holding repositories
                 'holding': HoldingRepository(self.session, factory=self),
                 'portfolio_holding': PortfolioHoldingRepository(self.session, factory=self),


### PR DESCRIPTION
Resolves import path issues and naming inconsistencies identified in issue #519

### Changes:
- Add missing src/ prefix to all portfolio entity imports
- Fix class name typo: CompanyShareOptionPortPortfolio → CompanyShareOptionPortfolioPort
- Remove duplicate repository factory registrations
- Update model docstrings to reference new entity paths
- Ensure consistency across ports, repositories, mappers, and factory

Generated with [Claude Code](https://claude.ai/code)