### PR TITLE
fix: update SQLAlchemy relationship references for renamed portfolio entities

### DIFF
--- a/src/infrastructure/models/__init__.py
+++ b/src/infrastructure/models/__init__.py
@@ -114,7 +114,7 @@ def ensure_models_registered():
         'CountryModel', 'IndustryModel', 'SectorModel', 'ExchangeModel', 'CompanyModel',
         'FinancialStatementModel', 'BalanceSheetModel', 'IncomeStatementModel', 'CashFlowStatementModel',
         'ShareModel', 'CompanyShareModel', 'ETFShareModel', 'ETFSharePortfolioCompanyShareModel', 
-        'PortfolioModel','PortfolioDerivativeModel', 'PortfolioCompanyShareModel', 'PortfolioCompanyShareOptionModel', 'PortfolioCompanyShareOptionDerivativeModel', 
+        'PortfolioModel','DerivativePortfolioModel', 'CompanySharePortfolioModel', 'CompanyShareOptionPortfolioModel', 'PortfolioCompanyShareOptionDerivativeModel', 
         'HoldingModel', 'PortfolioDerivativeHoldingModel', 'PortfolioCompanyShareOptionHoldingModel', 'IndexFutureOptionModel', 'IndexFutureModel', 'OptionsModel', 'CompanyShareOptionModel',
         'ETFSharePortfolioCompanyShareOptionModel', 'AccountModel', 'OrderModel', 'TransactionModel'
     }

--- a/src/infrastructure/models/finance/holding/derivative/portfolio_derivative_holding.py
+++ b/src/infrastructure/models/finance/holding/derivative/portfolio_derivative_holding.py
@@ -20,7 +20,7 @@ class PortfolioDerivativeHoldingModel(PortfolioHoldingsModel):
 
     # Relationships
     portfolio_derivative = relationship(
-        "src.infrastructure.models.finance.portfolio.portfolio_derivative.PortfolioDerivativeModel",
+        "src.infrastructure.models.finance.portfolio.portfolio_derivative.DerivativePortfolioModel",
         back_populates="portfolio_derivative_holdings"
     )
 

--- a/src/infrastructure/models/finance/holding/portfolio_company_share_holding.py
+++ b/src/infrastructure/models/finance/holding/portfolio_company_share_holding.py
@@ -16,7 +16,7 @@ class PortfolioCompanyShareHoldingModel(HoldingModel):
     portfolio_company_share_id = Column(Integer, ForeignKey('portfolio_company_shares.id'), nullable=False)
 
     # Relationships
-    portfolio_company_shares = relationship("src.infrastructure.models.finance.portfolio.portfolio_company_share.PortfolioCompanyShareModel", back_populates="portfolio_company_share_holdings")
+    portfolio_company_shares = relationship("src.infrastructure.models.finance.portfolio.portfolio_company_share.CompanySharePortfolioModel", back_populates="portfolio_company_share_holdings")
     company_shares = relationship("src.infrastructure.models.finance.financial_assets.company_share.CompanyShareModel", back_populates="portfolio_company_share_holdings")
 
     __mapper_args__ = {

--- a/src/infrastructure/models/finance/holding/portfolio_company_share_option_holding.py
+++ b/src/infrastructure/models/finance/holding/portfolio_company_share_option_holding.py
@@ -20,7 +20,7 @@ class PortfolioCompanyShareOptionHoldingModel(PortfolioHoldingsModel):
 
     # Relationships
     portfolio_company_share_option = relationship(
-        "src.infrastructure.models.finance.portfolio.portfolio_company_share_option.PortfolioCompanyShareOptionModel",
+        "src.infrastructure.models.finance.portfolio.portfolio_company_share_option.CompanyShareOptionPortfolioModel",
         back_populates="portfolio_company_share_option_holdings"
     )
 

--- a/src/infrastructure/repositories/mappers/MODELS_INVENTORY.md
+++ b/src/infrastructure/repositories/mappers/MODELS_INVENTORY.md
@@ -86,9 +86,9 @@ This document provides a comprehensive inventory of all SQLAlchemy models in the
 | Model | File | Mapper Status |
 |-------|------|---------------|
 | `PortfolioModel` | `finance/portfolio/portfolio.py` | ✅ Implemented |
-| `PortfolioCompanyShareModel` | `finance/portfolio/portfolio_company_share.py` | ✅ Implemented |
-| `PortfolioCompanyShareOptionModel` | `finance/portfolio/portfolio_company_share_option.py` | ✅ Implemented |
-| `PortfolioDerivativeModel` | `finance/portfolio/portfolio_derivative.py` | ✅ Implemented |
+| `CompanySharePortfolioModel` | `finance/portfolio/portfolio_company_share.py` | ✅ Implemented |
+| `CompanyShareOptionPortfolioModel` | `finance/portfolio/portfolio_company_share_option.py` | ✅ Implemented |
+| `DerivativePortfolioModel` | `finance/portfolio/portfolio_derivative.py` | ✅ Implemented |
 | `HoldingModel` | `finance/holding/holding.py` | ✅ Implemented |
 | `PortfolioHoldingsModel` | `finance/holding/portfolio_holding.py` | ✅ Implemented |
 | `PortfolioCompanyShareHoldingModel` | `finance/holding/portfolio_company_share_holding.py` | ✅ Implemented |
@@ -148,8 +148,8 @@ This document provides a comprehensive inventory of all SQLAlchemy models in the
 17. `ForwardContractModel` - Forward contracts
 18. `SwapModel` - Swap contracts
 19. `SwapLegModel` - Individual swap legs
-20. `PortfolioCompanyShareModel` - Portfolio share allocations
-21. `PortfolioDerivativeModel` - Portfolio derivative positions
+20. `CompanySharePortfolioModel` - Portfolio share allocations
+21. `DerivativePortfolioModel` - Portfolio derivative positions
 22. `SecurityHoldingModel` - Security holdings
 23. `FinancialAssetTimeSeriesModel` - Asset time series
 24. `StockTimeSeriesModel` - Stock time series
@@ -202,8 +202,8 @@ This document provides a comprehensive inventory of all SQLAlchemy models in the
 - `BalanceSheetModel` (balance sheets)
 - `IncomeStatementModel` (income statements)
 - `CashFlowStatementModel` (cash flow statements)
-- `PortfolioCompanyShareModel` (portfolio shares)
-- `PortfolioDerivativeModel` (portfolio derivatives)
+- `CompanySharePortfolioModel` (portfolio shares)
+- `DerivativePortfolioModel` (portfolio derivatives)
 - `SymbolModel` (trading symbols)
 
 ### Phase 5: Backtesting & Enums (8 mappers)


### PR DESCRIPTION
Fixes SQLAlchemy mapper initialization errors after portfolio entity renaming.

### Changes:
- Update holding models to reference correct renamed portfolio class names
- Fix PortfolioDerivativeModel → DerivativePortfolioModel
- Fix PortfolioCompanyShareModel → CompanySharePortfolioModel
- Fix PortfolioCompanyShareOptionModel → CompanyShareOptionPortfolioModel
- Update model registry in __init__.py for proper SQLAlchemy registration
- Update documentation to match new model names

Resolves issue #519

Generated with [Claude Code](https://claude.ai/code)