### PR TITLE
Fix SQLAlchemy mapping error in DerivativeModel relationships

### DIFF
--- a/src/infrastructure/models/__init__.py
+++ b/src/infrastructure/models/__init__.py
@@ -84,7 +84,7 @@ from src.infrastructure.models.finance.holding.portfolio_holding import Portfoli
 from src.infrastructure.models.finance.holding.security_holding import SecurityHoldingModel
 from src.infrastructure.models.finance.holding.company_share_portfolio_holding import CompanySharePortfolioHoldingModel
 from src.infrastructure.models.finance.holding.company_share_option_portfolio_holding import CompanyShareOptionPortfolioHoldingModel
-from infrastructure.models.finance.holding.derivative.derivative_portfolio_holding import DerivativePortfolioHoldingModel
+from src.infrastructure.models.finance.holding.derivative.derivative_portfolio_holding import DerivativePortfolioHoldingModel
 
 # Account, Order, and Transaction models
 from src.infrastructure.models.finance.account import AccountModel

--- a/src/infrastructure/models/finance/financial_assets/derivative/derivatives.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/derivatives.py
@@ -26,9 +26,9 @@ class DerivativeModel(FinancialAssetModel):
     )
     currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel",foreign_keys=[currency_id], back_populates="derivatives")
     
-    # ONE derivative → MANY portfolio_derivative_holdings
-    portfolio_derivative_holdings = relationship(
-        "src.infrastructure.models.finance.holding.derivative.portfolio_derivative_holding.PortfolioDerivativeHoldingModel",
+    # ONE derivative → MANY derivative_portfolio_holdings
+    derivative_portfolio_holdings = relationship(
+        "src.infrastructure.models.finance.holding.derivative.derivative_portfolio_holding.DerivativePortfolioHoldingModel",
         back_populates="derivative"
     )
     


### PR DESCRIPTION
Fixes SQLAlchemy mapper initialization error when creating derivative portfolios.

## Changes
- Fixed missing src. prefix in models/__init__.py import for DerivativePortfolioHoldingModel
- Corrected relationship reference from PortfolioDerivativeHoldingModel to DerivativePortfolioHoldingModel
- Updated relationship property name to derivative_portfolio_holdings for consistency

Resolves issue #531

Generated with [Claude Code](https://claude.ai/code)