### PR TITLE
Fix critical SQLAlchemy model relationship mismatches

### DIFF
--- a/src/infrastructure/models/finance/exchange.py
+++ b/src/infrastructure/models/finance/exchange.py
@@ -20,8 +20,6 @@ class ExchangeModel(Base):
     futures = relationship("src.infrastructure.models.finance.financial_assets.derivative.future.future.FutureModel", back_populates="exchange")
     index_future_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.index_future_option.IndexFutureOptionModel", back_populates="exchange")
     company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.company_share_option.CompanyShareOptionModel", back_populates="exchange")
-    etf_share_portfolio_company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.etf_share_portfolio_company_share_option.ETFSharePortfolioCompanyShareOptionModel", back_populates="exchange")
-    portfolio_company_share_options = relationship("src.infrastructure.models.finance.financial_assets.derivative.option.portfolio_company_share_option.PortfolioCompanyShareOptionDerivativeModel", back_populates="exchange")
     etf_share_portfolio_company_shares = relationship("src.infrastructure.models.finance.financial_assets.etf_share_portfolio_company_share.ETFSharePortfolioCompanyShareModel", back_populates="exchange")
     
     

--- a/src/infrastructure/models/finance/financial_assets/company_share.py
+++ b/src/infrastructure/models/finance/financial_assets/company_share.py
@@ -29,6 +29,6 @@ class CompanyShareModel(FinancialAssetModel):
     currency = relationship("src.infrastructure.models.finance.financial_assets.currency.CurrencyModel",foreign_keys=[currency_id], back_populates="company_shares")
     company = relationship("src.infrastructure.models.finance.company.CompanyModel", back_populates="company_shares")
     exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_shares") 
-    portfolio_company_share_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_company_share_holding.PortfolioCompanyShareHoldingModel", back_populates="company_shares") 
+    company_share_portfolio_holdings = relationship("src.infrastructure.models.finance.holding.company_share_portfolio_holding.CompanySharePortfolioHoldingModel", back_populates="company_shares") 
     def __repr__(self):
         return f"<CompanyShare(id={self.id}, ticker={self.ticker}, company_id={self.company_id})>"

--- a/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
+++ b/src/infrastructure/models/finance/financial_assets/derivative/option/company_share_option.py
@@ -24,7 +24,7 @@ class CompanyShareOptionModel(OptionsModel):
     multiplier = Column(Numeric(precision=10, scale=2), nullable=True, default=1.0)
     expiry = Column(String(20), nullable=True)
     exchange = relationship("src.infrastructure.models.finance.exchange.ExchangeModel", back_populates="company_share_options")
-    portfolio_company_share_option_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_company_share_option_holding.PortfolioCompanyShareOptionHoldingModel", back_populates="company_share_option") 
+    company_share_option_portfolio_holdings = relationship("src.infrastructure.models.finance.holding.company_share_option_portfolio_holding.CompanyShareOptionPortfolioHoldingModel", back_populates="company_share_option") 
     
     
     __mapper_args__ = {

--- a/src/infrastructure/models/finance/order/order.py
+++ b/src/infrastructure/models/finance/order/order.py
@@ -14,7 +14,7 @@ class OrderModel(Base):
     quantity = Column(Float, nullable=False)
     created_at = Column(DateTime, nullable=False)
     status = Column(Enum(OrderStatus), nullable=False)
-    account_id = Column(Integer, ForeignKey('accounts.account_id'), nullable=False)
+    account_id = Column(Integer, ForeignKey('accounts.id'), nullable=False)
     price = Column(Float, nullable=True)
     stop_price = Column(Float, nullable=True)
     filled_quantity = Column(Float, nullable=False, default=0.0)

--- a/src/infrastructure/models/finance/portfolio/company_share_option_portfolio.py
+++ b/src/infrastructure/models/finance/portfolio/company_share_option_portfolio.py
@@ -17,7 +17,7 @@ class CompanyShareOptionPortfolioModel(PortfolioModel):
     # ONE portfolio_company_share_option → MANY portfolio_company_share_option_holdings
     portfolio_company_share_option_holdings = relationship(
         "src.infrastructure.models.finance.holding.company_share_option_portfolio_holding.CompanyShareOptionPortfolioHoldingModel", 
-        back_populates="company_share_option_portfolios"
+        back_populates="portfolio_company_share_option"
     )
     
     __mapper_args__ = {

--- a/src/infrastructure/models/finance/portfolio/derivative_portfolio.py
+++ b/src/infrastructure/models/finance/portfolio/derivative_portfolio.py
@@ -17,7 +17,7 @@ class DerivativePortfolioModel(PortfolioModel):
     # ONE portfolio_derivative → MANY portfolio_derivative_holdings
     portfolio_derivative_holdings = relationship(
         "src.infrastructure.models.finance.holding.derivative.derivative_portfolio_holding.DerivativePortfolioHoldingModel", 
-        back_populates="derivative_portfolios"
+        back_populates="derivative_portfolio"
     )
     
     __mapper_args__ = {

--- a/src/infrastructure/models/finance/portfolio/portfolio.py
+++ b/src/infrastructure/models/finance/portfolio/portfolio.py
@@ -19,7 +19,7 @@ class PortfolioModel(Base):
 
     # ONE portfolio → MANY positions
     positions = relationship("src.infrastructure.models.finance.position.PositionModel",back_populates="portfolios",cascade="all, delete-orphan")
-    portfolio_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_holding.PortfolioHoldingsModel", back_populates="portfolios")
+    portfolio_holdings = relationship("src.infrastructure.models.finance.holding.portfolio_holding.PortfolioHoldingsModel", back_populates="portfolio")
     security_holdings = relationship("src.infrastructure.models.finance.holding.security_holding.SecurityHoldingModel", back_populates="portfolios")
     securities = relationship("src.infrastructure.models.finance.financial_assets.security.SecurityModel", back_populates="portfolios")
     __mapper_args__ = {


### PR DESCRIPTION
Resolved 7 critical relationship issues preventing proper model initialization:

1. DerivativePortfolioModel: Fixed back_populates mismatch with DerivativePortfolioHoldingModel
2. CompanyShareOptionPortfolioModel: Fixed back_populates with CompanyShareOptionPortfolioHoldingModel  
3. PortfolioModel: Fixed back_populates with PortfolioHoldingsModel
4. ExchangeModel: Removed references to non-existent model classes
5. CompanyShareOptionModel: Fixed import path and class name reference
6. OrderModel: Fixed foreign key reference to accounts.id instead of accounts.account_id
7. CompanyShareModel: Standardized relationship naming with CompanySharePortfolioHoldingModel

These fixes resolve SQLAlchemy mapper initialization errors when creating portfolios.

Resolves issue #531

🤖 Generated with [Claude Code](https://claude.ai/code)