### PR TITLE
Fix SQLAlchemy relationship naming mismatch in DerivativePortfolio models

### DIFF
--- a/src/infrastructure/models/finance/holding/derivative/derivative_portfolio_holding.py
+++ b/src/infrastructure/models/finance/holding/derivative/derivative_portfolio_holding.py
@@ -19,7 +19,7 @@ class DerivativePortfolioHoldingModel(PortfolioHoldingsModel):
     derivative_id = Column(Integer, ForeignKey("derivatives.id"), nullable=False)
 
     # Relationships
-    derivative_portfolios = relationship(
+    derivative_portfolio = relationship(
         "src.infrastructure.models.finance.portfolio.derivative_portfolio.DerivativePortfolioModel",
         back_populates="derivative_portfolio_holdings"
     )

--- a/src/infrastructure/models/finance/portfolio/derivative_portfolio.py
+++ b/src/infrastructure/models/finance/portfolio/derivative_portfolio.py
@@ -14,10 +14,10 @@ class DerivativePortfolioModel(PortfolioModel):
     
     
 
-    # ONE portfolio_derivative → MANY portfolio_derivative_holdings
-    portfolio_derivative_holdings = relationship(
+    # ONE portfolio_derivative → MANY derivative_portfolio_holdings
+    derivative_portfolio_holdings = relationship(
         "src.infrastructure.models.finance.holding.derivative.derivative_portfolio_holding.DerivativePortfolioHoldingModel", 
-        back_populates="derivative_portfolios"
+        back_populates="derivative_portfolio"
     )
     
     __mapper_args__ = {


### PR DESCRIPTION
Resolves the SQLAlchemy error: "Mapper has no property 'derivative_portfolio_holdings'"

## Changes
- Fixed relationship naming mismatch between DerivativePortfolioModel and DerivativePortfolioHoldingModel
- Renamed `portfolio_derivative_holdings` to `derivative_portfolio_holdings` in DerivativePortfolioModel
- Renamed `derivative_portfolios` to `derivative_portfolio` in DerivativePortfolioHoldingModel
- Updated back_populates references to match relationship property names

Resolves issue #531

🤖 Generated with [Claude Code](https://claude.ai/code)