### PR TITLE
fix: store factor values in batch optimized function

### DIFF
--- a/src/infrastructure/repositories/ibkr_repo/factor/ibkr_factor_value_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/factor/ibkr_factor_value_repository.py
@@ -534,7 +534,7 @@ class IBKRFactorValueRepository(BaseIBKRFactorRepository, FactorValuePort):
                 return None
 
             # Batch persist all factor values to database
-            #self._batch_persist_factor_values(created_factor_values)
+            self._batch_persist_factor_values(created_factor_values)
 
             # Create result batch with metadata
             result_metadata = {


### PR DESCRIPTION
Fixes issue #540 where get_or_create_batch_optimized function was not storing factor values in the database.

The batch persistence function _batch_persist_factor_values was commented out in the get_or_create_batch function, preventing factor values from being saved to the database. This fix uncomments that line to restore proper functionality.

Generated with [Claude Code](https://claude.ai/code)