### PR TITLE
feat: Add dependency name mapping for factor calculations

### DIFF
--- a/src/application/services/data/entities/factor/factor_value_resolution_service.py
+++ b/src/application/services/data/entities/factor/factor_value_resolution_service.py
@@ -249,7 +249,8 @@ class FactorValueResolutionService:
                     'independent_factor_id': dependency.independent_factor_id,
                     'dependent_factor_id': dependency.dependent_factor_id,
                     'lag': dependency.lag,
-                    'dependency_entity': dependency
+                    'dependency_entity': dependency,
+                    'dependency_name': dependency.dependency_name
                 }
                 dependency_list.append(dependency_info)
             
@@ -275,8 +276,12 @@ class FactorValueResolutionService:
             
             for dependency in dependencies:
                 independent_factor_id = dependency['independent_factor_id']
-                
                 lag = dependency.get('lag')
+                dependency_name = dependency.get('dependency_name')
+                
+                # If no dependency name is specified, fall back to generic naming
+                if not dependency_name:
+                    dependency_name = f"factor_{independent_factor_id}_{lag}" if lag else f"factor_{independent_factor_id}"
                 
                 # Calculate dependency date with lag
                 dependency_date = target_date
@@ -293,8 +298,7 @@ class FactorValueResolutionService:
                 )
                 
                 if dependency_value:
-                    key = f"factor_{independent_factor_id}_{lag}"
-                    dependency_values[key] = self._convert_to_float(dependency_value.value)
+                    dependency_values[dependency_name] = self._convert_to_float(dependency_value.value)
                 else:
                     # Handle missing dependencies based on repository type
                     dependency_resolved = self._handle_missing_dependency(
@@ -302,11 +306,10 @@ class FactorValueResolutionService:
                     )
                     
                     if dependency_resolved:
-                        key = f"factor_{independent_factor_id}_{lag}"
-                        dependency_values[key] = self._convert_to_float(dependency_resolved.value)
+                        dependency_values[dependency_name] = self._convert_to_float(dependency_resolved.value)
                     else:
                         missing_dependencies.append(dependency["dependency_entity"])
-                        self.logger.error(f"Failed to resolve dependency factor {independent_factor_id} for {repository_type} repository")
+                        self.logger.error(f"Failed to resolve dependency factor {independent_factor_id} ('{dependency_name}') for {repository_type} repository")
             
             # If there are missing dependencies, flag error and do not assign 0
             if missing_dependencies:
@@ -515,7 +518,25 @@ class FactorValueResolutionService:
         try:
             if hasattr(factor_entity, 'calculate') and callable(getattr(factor_entity, 'calculate')):
                 calculate_method = getattr(factor_entity, 'calculate')
-                result = calculate_method(dependency_values, **kwargs)
+                
+                # Get function signature to determine how to call the method
+                import inspect
+                signature = inspect.signature(calculate_method)
+                method_params = list(signature.parameters.keys())
+                
+                # Prepare arguments for the calculate method
+                call_kwargs = {}
+                for param_name in method_params:
+                    if param_name in dependency_values:
+                        call_kwargs[param_name] = dependency_values[param_name]
+                
+                # Add any additional kwargs that match method parameters
+                for key, value in kwargs.items():
+                    if key in method_params:
+                        call_kwargs[key] = value
+                
+                # Call the calculate method with the prepared arguments
+                result = calculate_method(**call_kwargs)
                 
                 if result is not None:
                     return float(result)
@@ -529,6 +550,8 @@ class FactorValueResolutionService:
                 
         except Exception as e:
             self.logger.error(f"Error calling factor calculate method: {e}")
+            self.logger.error(f"Available dependencies: {list(dependency_values.keys())}")
+            self.logger.error(f"Factor: {factor_entity.name}")
             return None
     
     def _create_factor_value(

--- a/src/domain/entities/factor/factor_dependency.py
+++ b/src/domain/entities/factor/factor_dependency.py
@@ -22,7 +22,8 @@ class FactorDependency:
     independent_factor_id: int
     id: Optional[int] = None
     lag: Optional[timedelta] = None
-    independent_factor_related_entity_key: Any = None # it can be it the dependent entity, or a related entity 
+    independent_factor_related_entity_key: Any = None # it can be it the dependent entity, or a related entity
+    dependency_name: Optional[str] = None  # Parameter name in the calculate method (e.g., "start_price", "end_price") 
     
     def __post_init__(self):
         """Validate the factor dependency relationship."""
@@ -37,4 +38,5 @@ class FactorDependency:
     
     def __repr__(self) -> str:
         return (f"FactorDependency(id={self.id}, dependent_factor_id={self.dependent_factor_id}, "
-                f"independent_factor_id={self.independent_factor_id}, lag={self.lag})")
+                f"independent_factor_id={self.independent_factor_id}, lag={self.lag}, "
+                f"dependency_name={self.dependency_name})")

--- a/src/infrastructure/mappers/factor_dependency_mapper.py
+++ b/src/infrastructure/mappers/factor_dependency_mapper.py
@@ -36,7 +36,8 @@ class FactorDependencyMapper:
             dependent_factor_id=model.dependent_factor_id,
             independent_factor_id=model.independent_factor_id,
             lag=model.lag,
-            independent_factor_related_entity_key=model.independent_factor_related_entity_key
+            independent_factor_related_entity_key=model.independent_factor_related_entity_key,
+            dependency_name=model.dependency_name
         )
     
     @staticmethod
@@ -55,7 +56,8 @@ class FactorDependencyMapper:
             dependent_factor_id=entity.dependent_factor_id,
             independent_factor_id=entity.independent_factor_id,
             lag=entity.lag,
-            independent_factor_related_entity_key=entity.independent_factor_related_entity_key
+            independent_factor_related_entity_key=entity.independent_factor_related_entity_key,
+            dependency_name=entity.dependency_name
         )
     
     @staticmethod
@@ -100,4 +102,5 @@ class FactorDependencyMapper:
         model.independent_factor_id = entity.independent_factor_id
         model.lag = entity.lag
         model.independent_factor_related_entity_key = entity.independent_factor_related_entity_key
+        model.dependency_name = entity.dependency_name
         return model

--- a/src/infrastructure/models/factor/factor_dependency.py
+++ b/src/infrastructure/models/factor/factor_dependency.py
@@ -15,6 +15,7 @@ class FactorDependencyModel(Base):
     independent_factor_id = Column(Integer, ForeignKey('factors.id'), nullable=False)
     lag = Column(Interval, nullable=True)  # Time lag for dependency resolution
     independent_factor_related_entity_key = Column(String, nullable=True) #"underlying_asset_id"
+    dependency_name = Column(String, nullable=True)  # Parameter name in the calculate method
     
     # Relationships to FactorModel
     dependent_factor = relationship(
@@ -33,5 +34,6 @@ class FactorDependencyModel(Base):
         return (f"<FactorDependency(id={self.id}, "
                 f"dependent_factor_id={self.dependent_factor_id}, "
                 f"independent_factor_id={self.independent_factor_id}, "
-                f"lag={self.lag})>,"
-                f"independent_factor_related_entity_key={self.independent_factor_related_entity_key})>")
+                f"lag={self.lag}, "
+                f"independent_factor_related_entity_key={self.independent_factor_related_entity_key}, "
+                f"dependency_name={self.dependency_name})>")

--- a/src/infrastructure/repositories/ibkr_repo/factor/ibkr_factor_value_repository.py
+++ b/src/infrastructure/repositories/ibkr_repo/factor/ibkr_factor_value_repository.py
@@ -1127,6 +1127,7 @@ class IBKRFactorValueRepository(BaseIBKRFactorRepository, FactorValuePort):
                         'dependency_id': dep.id,
                         'lag': dep.lag,
                         'independent_factor_related_entity_key': dep.independent_factor_related_entity_key,
+                        'dependency_name': dep.dependency_name,
                         'static_dependency': True
                     })
             
@@ -1272,9 +1273,14 @@ class IBKRFactorValueRepository(BaseIBKRFactorRepository, FactorValuePort):
                 independent_factor_id = dep_info['independent_factor_id']
                 lag = dep_info.get('lag')
                 independent_factor_related_entity_key = dep_info.get('independent_factor_related_entity_key')
+                dependency_name = dep_info.get('dependency_name')
                 
-                # Determine parameter name based on factor type and dependency position
-                param_name = self._get_dependency_parameter_name(factor, i, len(dependencies), independent_factor)
+                # Use dependency name if available, otherwise fall back to auto-naming
+                if dependency_name:
+                    param_name = dependency_name
+                else:
+                    # Determine parameter name based on factor type and dependency position
+                    param_name = self._get_dependency_parameter_name(factor, i, len(dependencies), independent_factor)
                 
                 # Calculate the adjusted date considering the lag
                 dependency_date = bar_date

--- a/src/infrastructure/repositories/local_repo/factor/factor_value_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/factor_value_repository.py
@@ -233,7 +233,8 @@ class FactorValueRepository(BaseLocalRepository, FactorValuePort):
                     'independent_factor_id': dependency.independent_factor_id,
                     'dependent_factor_id': dependency.dependent_factor_id,
                     'lag': dependency.lag,
-                    'dependency_entity': dependency
+                    'dependency_entity': dependency,
+                    'dependency_name': dependency.dependency_name
                 }
                 dependency_list.append(dependency_info)
             
@@ -273,12 +274,17 @@ class FactorValueRepository(BaseLocalRepository, FactorValuePort):
                     dependency_values[parameter] = None  # Initialize with None
 
 
-            for i, dependency in enumerate(dependencies):#for dependency in dependencies:
-                independent_factor = dependency['independent_factor']
+            for i, dependency in enumerate(dependencies):
                 independent_factor_id = dependency['independent_factor_id']
                 lag = dependency.get('lag')
+                dependency_entity = dependency.get('dependency_entity')
                 
-
+                # Get the dependency name from the dependency entity
+                dependency_name = getattr(dependency_entity, 'dependency_name', None) if dependency_entity else None
+                
+                # If no dependency name is specified, fall back to generic naming
+                if not dependency_name:
+                    dependency_name = f"factor_{independent_factor_id}_{lag}" if lag else f"factor_{independent_factor_id}"
 
                 # Calculate dependency date with lag
                 dependency_date = target_date
@@ -295,11 +301,10 @@ class FactorValueRepository(BaseLocalRepository, FactorValuePort):
                 )
                 
                 if dependency_value:
-                    # Use the factor name as key if available
-                    dependency_key = f"factor_{independent_factor_id}_{lag}" if lag else f"factor_{independent_factor_id}"
-                    dependency_values[dependency_key] = float(dependency_value.value)
+                    # Use the dependency name as the key for the calculate method
+                    dependency_values[dependency_name] = float(dependency_value.value)
                 else:
-                    print(f"Could not resolve dependency factor {independent_factor_id} for date {dependency_date_str}")
+                    print(f"Could not resolve dependency factor {independent_factor_id} ('{dependency_name}') for date {dependency_date_str}")
                     # Flag error instead of assigning 0.0
                     print(f"Local repository cannot resolve missing dependency - failing calculation")
                     return None
@@ -381,8 +386,23 @@ class FactorValueRepository(BaseLocalRepository, FactorValuePort):
                 calculate_method = getattr(factor, 'calculate')
                 
                 try:
-                    # Call the calculate method with dependency values
-                    result = calculate_method(dependency_values, **kwargs)
+                    # Get function signature to determine how to call the method
+                    signature = inspect.signature(calculate_method)
+                    method_params = list(signature.parameters.keys())
+                    
+                    # Prepare arguments for the calculate method
+                    call_kwargs = {}
+                    for param_name in method_params:
+                        if param_name in dependency_values:
+                            call_kwargs[param_name] = dependency_values[param_name]
+                    
+                    # Add any additional kwargs that match method parameters
+                    for key, value in kwargs.items():
+                        if key in method_params:
+                            call_kwargs[key] = value
+                    
+                    # Call the calculate method with the prepared arguments
+                    result = calculate_method(**call_kwargs)
                     
                     if result is not None:
                         return float(result)
@@ -392,6 +412,8 @@ class FactorValueRepository(BaseLocalRepository, FactorValuePort):
                         
                 except Exception as calc_error:
                     print(f"Error calling calculate method for factor {factor.name}: {calc_error}")
+                    print(f"Available dependencies: {list(dependency_values.keys())}")
+                    print(f"Method signature: {signature}")
                     return None
             else:
                 print(f"Factor {factor.name} has dependencies but no calculate method")


### PR DESCRIPTION
Add dependency_name field to support factor calculations with named parameters.

Changes:
- Add dependency_name field to FactorDependency entity and model
- Update dependency resolution to use parameter names from database
- Enhance calculate method calls with signature inspection
- Support return_daily_3 factor with start_price/end_price mapping

Enables factor dependencies like return_daily_3 to map to specific calculate method parameters instead of auto-generated keys.

Generated with [Claude Code](https://claude.ai/code)