### PR TITLE
feat: Add dependency_name parameter to factor dependency creation

### DIFF
--- a/src/infrastructure/repositories/local_repo/factor/factor_dependency_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/factor_dependency_repository.py
@@ -76,7 +76,8 @@ class FactorDependencyRepository(BaseLocalRepository[FactorDependency, FactorDep
                 'dependent_factor_id': entity.dependent_factor_id,
                 'independent_factor_id': entity.independent_factor_id,
                 'lag': entity.lag,
-                'independent_factor_related_entity_key': entity.independent_factor_related_entity_key
+                'independent_factor_related_entity_key': entity.independent_factor_related_entity_key,
+                'dependency_name': entity.dependency_name
             }
             updated_model = super().update(entity.id, updates)
             return FactorDependencyMapper.model_to_entity(updated_model) if updated_model else None
@@ -102,7 +103,7 @@ class FactorDependencyRepository(BaseLocalRepository[FactorDependency, FactorDep
         ).count()
         return count > 0
     
-    def _create_or_get(self, independent_factor, dependent_factor, lag=None,independent_factor_related_entity_key=None ) -> Optional[FactorDependency]:
+    def _create_or_get(self, independent_factor, dependent_factor, lag=None, independent_factor_related_entity_key=None, dependency_name=None) -> Optional[FactorDependency]:
         """
         Create or get a factor dependency relationship.
         
@@ -110,6 +111,8 @@ class FactorDependencyRepository(BaseLocalRepository[FactorDependency, FactorDep
             independent_factor: Domain entity of the independent factor
             dependent_factor: Domain entity of the dependent factor
             lag: Optional timedelta for time-based dependency lag
+            independent_factor_related_entity_key: Optional key for related entity
+            dependency_name: Optional name for the dependency parameter (e.g., "start_price", "end_price")
             
         Returns:
             FactorDependency entity or None if creation failed
@@ -140,7 +143,8 @@ class FactorDependencyRepository(BaseLocalRepository[FactorDependency, FactorDep
                 dependent_factor_id=dependent_factor_id,
                 independent_factor_id=independent_factor_id,
                 lag=lag,
-                independent_factor_related_entity_key=independent_factor_related_entity_key
+                independent_factor_related_entity_key=independent_factor_related_entity_key,
+                dependency_name=dependency_name
             )
             
             return self.add(dependency_entity)

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/future/future_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/future/future_price_return_factor_repository.py
@@ -111,7 +111,7 @@ class FuturePriceReturnFactorRepository(BaseFactorRepository):
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor =dependency_entity ,dependent_factor = self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor =dependency_entity ,dependent_factor = self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/future/index_future_option_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/future/index_future_option_price_return_factor_repository.py
@@ -115,7 +115,7 @@ class IndexFutureOptionPriceReturnFactorRepository(BaseFactorRepository):
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity,dependent_factor = self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity,dependent_factor = self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/future/index_future_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/future/index_future_price_return_factor_repository.py
@@ -111,7 +111,7 @@ class IndexFuturePriceReturnFactorRepository(BaseFactorRepository):
 
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = dependency_config.get("parameters").get("lag"))
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = dependency_config.get("parameters").get("lag"), dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_bates_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_bates_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionBatesPriceFactorRepository(BaseFactorRepository, Company
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_black_scholes_merton_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_black_scholes_merton_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionBlackScholesMertonPriceFactorRepository(BaseFactorReposi
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_cox_ross_rubinstein_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_cox_ross_rubinstein_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionCoxRossRubinsteinPriceFactorRepository(BaseFactorReposit
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_delta_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_delta_factor_repository.py
@@ -114,7 +114,7 @@ class CompanyShareOptionDeltaFactorRepository(BaseFactorRepository):
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_dupire_local_volatility_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_dupire_local_volatility_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionDupireLocalVolatilityPriceFactorRepository(BaseFactorRep
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_factor_repository.py
@@ -114,7 +114,7 @@ class CompanyShareOptionFactorRepository(BaseFactorRepository):
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_heston_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_heston_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionHestonPriceFactorRepository(BaseFactorRepository, Compan
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_hull_white_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_hull_white_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionHullWhitePriceFactorRepository(BaseFactorRepository, Com
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_mid_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_mid_price_factor_repository.py
@@ -80,7 +80,7 @@ class CompanyShareOptionMidPriceFactorRepository(CompanyShareOptionMidPriceFacto
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag",None) if dependency_config.get("parameters") else None
                     independent_factor_related_entity_key = dependency_config.get("parameters", {}).get("independent_factor_related_entity_key",None) if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = lag, independent_factor_related_entity_key=independent_factor_related_entity_key )
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = lag, independent_factor_related_entity_key=independent_factor_related_entity_key, dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionPriceFactorRepository(BaseFactorRepository):
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag",None) if dependency_config.get("parameters") else None
                     independent_factor_related_entity_key = dependency_config.get("parameters", {}).get("independent_factor_related_entity_key",None) if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = lag, independent_factor_related_entity_key=independent_factor_related_entity_key )
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = lag, independent_factor_related_entity_key=independent_factor_related_entity_key, dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_price_return_factor_repository.py
@@ -111,7 +111,7 @@ class CompanyShareOptionPriceReturnFactorRepository(BaseFactorRepository):
 
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = dependency_config.get("parameters").get("lag"))
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag = dependency_config.get("parameters").get("lag"), dependency_name=dependency[0])
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_sabr_price_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_option/company_share_option_sabr_price_factor_repository.py
@@ -115,7 +115,7 @@ class CompanyShareOptionSABRPriceFactorRepository(BaseFactorRepository, CompanyS
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_portfolio_option/company_share_portfolio_option_delta_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_portfolio_option/company_share_portfolio_option_delta_factor_repository.py
@@ -113,7 +113,7 @@ class CompanySharePortfolioOptionDeltaFactorRepository(BaseFactorRepository):
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity,dependent_factor = self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity,dependent_factor = self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_portfolio_option/company_share_portfolio_option_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_portfolio_option/company_share_portfolio_option_factor_repository.py
@@ -114,7 +114,7 @@ class CompanySharePortfolioOptionFactorRepository(BaseFactorRepository):
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_portfolio_option/company_share_portfolio_option_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/derivatives/option/company_share_portfolio_option/company_share_portfolio_option_price_return_factor_repository.py
@@ -113,7 +113,7 @@ class CompanySharePortfolioOptionPriceReturnFactorRepository(BaseFactorRepositor
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity,dependent_factor =self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity,dependent_factor =self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
 
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index/index_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/index/index_price_return_factor_repository.py
@@ -122,7 +122,7 @@ class IndexPriceReturnFactorRepository(BaseFactorRepository):
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity ,dependent_factor = self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity ,dependent_factor = self._to_entity(orm_factor), lag=lag, dependency_name=dependency[0])
  
             
             if orm_factor:

--- a/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share/company_share/company_share_price_return_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/financial_assets/share/company_share/company_share_price_return_factor_repository.py
@@ -68,11 +68,10 @@ class CompanySharePriceReturnFactorRepository(BaseFactorRepository, CompanyShare
             #create_or_get dependencies
             if kwargs.get('dependencies'):
                 dependencies = kwargs.get('dependencies')
-                for dependency in dependencies.items():
-                    entity_class = dependency[1].get('class')
+                for dependency_name, dependency_config in dependencies.items():
+                    entity_class = dependency_config.get('class')
                     repo = self.factory.get_local_repository(entity_class)
                     
-                    dependency_config = dependency[1]
                     dependency_entity = repo._create_or_get(
                             entity_class,
                             primary_key=dependency_config.get("name"),
@@ -87,7 +86,12 @@ class CompanySharePriceReturnFactorRepository(BaseFactorRepository, CompanyShare
 
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag") if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor = dependency_entity,dependent_factor = self._to_entity(orm_factor), lag=lag)
+                    repo_factor_dependency._create_or_get(
+                        independent_factor=dependency_entity,
+                        dependent_factor=self._to_entity(orm_factor), 
+                        lag=lag,
+                        dependency_name=dependency_name
+                    )
  
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/holding/company_share_portfolio_holding_value_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/holding/company_share_portfolio_holding_value_factor_repository.py
@@ -123,7 +123,8 @@ class CompanySharePortfolioHoldingValueFactorRepository(BaseFactorRepository):
                     independent_factor=dependency_entity, 
                     dependent_factor=self._to_entity(orm_factor), 
                     lag=lag, 
-                    independent_factor_related_entity_key=independent_factor_related_entity_key
+                    independent_factor_related_entity_key=independent_factor_related_entity_key,
+                    dependency_name=dependency[0]
                 )
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/portfolio/company_share_portfolio/company_share_portfolio_value_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/portfolio/company_share_portfolio/company_share_portfolio_value_factor_repository.py
@@ -123,7 +123,8 @@ class CompanySharePortfolioValueFactorRepository(BaseFactorRepository):
                     independent_factor=dependency_entity, 
                     dependent_factor=self._to_entity(orm_factor), 
                     lag=lag, 
-                    independent_factor_related_entity_key=independent_factor_related_entity_key
+                    independent_factor_related_entity_key=independent_factor_related_entity_key,
+                    dependency_name=dependency[0]
                 )
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/portfolio/portfolio_value_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/portfolio/portfolio_value_factor_repository.py
@@ -92,7 +92,8 @@ class PortfolioValueFactorRepository(BaseFactorRepository, PortfolioValueFactorP
                         independent_factor=dependency_entity, 
                         dependent_factor=self._to_entity(orm_factor), 
                         lag=lag, 
-                        independent_factor_related_entity_key=independent_factor_related_entity_key
+                        independent_factor_related_entity_key=independent_factor_related_entity_key,
+                        dependency_name=dependency[0]
                     )
             
             self.session.commit()

--- a/src/infrastructure/repositories/local_repo/factor/finance/position/company_share_position_value_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/position/company_share_position_value_factor_repository.py
@@ -88,7 +88,7 @@ class CompanySharePositionValueFactorRepository(BaseFactorRepository, CompanySha
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag", None) if dependency_config.get("parameters") else None
                     independent_factor_related_entity_key = dependency_config.get("parameters", {}).get("independent_factor_related_entity_key", None) if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, independent_factor_related_entity_key=independent_factor_related_entity_key)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, independent_factor_related_entity_key=independent_factor_related_entity_key, dependency_name=dependency[0])
  
             self.session.commit()
             if orm_factor:

--- a/src/infrastructure/repositories/local_repo/factor/finance/transaction/company_share_transaction_value_factor_repository.py
+++ b/src/infrastructure/repositories/local_repo/factor/finance/transaction/company_share_transaction_value_factor_repository.py
@@ -88,7 +88,7 @@ class CompanyShareTransactionValueFactorRepository(BaseFactorRepository, Company
                     repo_factor_dependency = self.factory.get_local_repository(FactorDependency)
                     lag = dependency_config.get("parameters", {}).get("lag", None) if dependency_config.get("parameters") else None
                     independent_factor_related_entity_key = dependency_config.get("parameters", {}).get("independent_factor_related_entity_key", None) if dependency_config.get("parameters") else None
-                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, independent_factor_related_entity_key=independent_factor_related_entity_key)
+                    repo_factor_dependency._create_or_get(independent_factor=dependency_entity, dependent_factor=self._to_entity(orm_factor), lag=lag, independent_factor_related_entity_key=independent_factor_related_entity_key, dependency_name=dependency[0])
  
             self.session.commit()
             if orm_factor:


### PR DESCRIPTION
Add dependency_name parameter to support factor calculations with named parameters.

Changes:
- Update FactorDependencyRepository._create_or_get to accept dependency_name parameter
- Update all factor repositories to pass dependency name from factor configuration
- Enables proper parameter mapping for factor calculations (e.g., start_price, end_price)
- Supports return_daily_3 factor with named parameter dependencies

Generatedwith [Claude Code](https://claude.ai/code)