### PR TITLE
feat: add CompanySharePortfolioPortfolioHolding entity

### DIFF
--- a/src/domain/entities/finance/holding/company_share_portfolio_portfolio_holding.py
+++ b/src/domain/entities/finance/holding/company_share_portfolio_portfolio_holding.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from src.domain.entities.finance.holding.portfolio_holding import PortfolioHolding
+from src.domain.entities.finance.holding.position import Position
+from src.domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio
+from src.domain.entities.finance.portfolio.portfolio import Portfolio
+
+
+class CompanySharePortfolioPortfolioHolding(PortfolioHolding):
+    """
+    A holding that represents a CompanySharePortfolio (asset) held within a Portfolio (container).
+    
+    This allows portfolios to contain other portfolios as positions, creating a hierarchical 
+    portfolio structure where a main portfolio can hold sub-portfolios of company shares.
+    """
+
+    def __init__(
+        self,
+        id: int,
+        portfolio: Portfolio,
+        company_share_portfolio: CompanySharePortfolio,
+        position: Position,
+        start_date: datetime,
+        end_date: Optional[datetime] = None,
+    ):
+        super().__init__(
+            id=id,
+            portfolio=portfolio,
+            asset=company_share_portfolio,
+            position=position,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        self.company_share_portfolio = company_share_portfolio

--- a/src/infrastructure/models/finance/holding/company_share_portfolio_portfolio_holding.py
+++ b/src/infrastructure/models/finance/holding/company_share_portfolio_portfolio_holding.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+from src.infrastructure.models.finance.holding.portfolio_holding import PortfolioHoldingsModel
+
+
+class CompanySharePortfolioPortfolioHoldingModel(PortfolioHoldingsModel):
+    """
+    SQLAlchemy model for CompanySharePortfolio holdings within a Portfolio.
+    Maps to domain.entities.finance.holding.company_share_portfolio_portfolio_holding.CompanySharePortfolioPortfolioHolding
+    
+    Represents a holding where a Portfolio (container) holds a CompanySharePortfolio (asset).
+    """
+    __tablename__ = 'company_share_portfolio_portfolio_holdings'
+    
+    id = Column(Integer, ForeignKey("portfolio_holdings.id"), primary_key=True)
+    asset_id = Column(Integer, ForeignKey('company_share_portfolios.id'), nullable=False)
+
+    # Relationships
+    company_share_portfolio = relationship(
+        "src.infrastructure.models.finance.portfolio.company_share_portfolio.CompanySharePortfolioModel", 
+        foreign_keys=[asset_id],
+        back_populates="company_share_portfolio_portfolio_holdings"
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": "company_share_portfolio_portfolio_holdings",
+    }

--- a/src/infrastructure/models/finance/portfolio/company_share_portfolio.py
+++ b/src/infrastructure/models/finance/portfolio/company_share_portfolio.py
@@ -13,5 +13,6 @@ class CompanySharePortfolioModel(PortfolioModel):
 
     
     company_share_portfolio_holdings = relationship("src.infrastructure.models.finance.holding.company_share_portfolio_holding.CompanySharePortfolioHoldingModel", back_populates="company_share_portfolios")
+    company_share_portfolio_portfolio_holdings = relationship("src.infrastructure.models.finance.holding.company_share_portfolio_portfolio_holding.CompanySharePortfolioPortfolioHoldingModel", back_populates="company_share_portfolio")
     __mapper_args__ = {
     "polymorphic_identity": "company_share_portfolios",}

--- a/test_company_share_portfolio_portfolio_holding.py
+++ b/test_company_share_portfolio_portfolio_holding.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Simple test script to verify the new CompanySharePortfolioPortfolioHolding entities work correctly
+"""
+
+def test_imports():
+    """Test that all new components can be imported without errors"""
+    try:
+        # Test domain entities
+        from src.domain.entities.finance.holding.company_share_portfolio_portfolio_holding import CompanySharePortfolioPortfolioHolding
+        from src.domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio
+        from src.domain.entities.finance.portfolio.portfolio import Portfolio
+        from src.domain.entities.finance.holding.position import Position
+        
+        # Test infrastructure models
+        from src.infrastructure.models.finance.holding.company_share_portfolio_portfolio_holding import CompanySharePortfolioPortfolioHoldingModel
+        from src.infrastructure.models.finance.portfolio.company_share_portfolio import CompanySharePortfolioModel
+        
+        print("✅ All imports successful!")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Import error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def test_entity_creation():
+    """Test basic entity creation"""
+    try:
+        from datetime import date, datetime
+        from src.domain.entities.finance.holding.company_share_portfolio_portfolio_holding import CompanySharePortfolioPortfolioHolding
+        from src.domain.entities.finance.portfolio.company_share_portfolio import CompanySharePortfolio
+        from src.domain.entities.finance.portfolio.portfolio import Portfolio
+        from src.domain.entities.finance.holding.position import Position
+        
+        # Create basic entities for testing
+        portfolio = Portfolio(
+            id=1,
+            name="Main Portfolio",
+            start_date=date.today()
+        )
+        
+        company_share_portfolio = CompanySharePortfolio(
+            id=2,
+            name="Tech Stocks Portfolio",
+            start_date=date.today()
+        )
+        
+        position = Position(id=1, quantity=100)  # Assuming Position takes these params
+        
+        # Create the holding
+        holding = CompanySharePortfolioPortfolioHolding(
+            id=1,
+            portfolio=portfolio,
+            company_share_portfolio=company_share_portfolio,
+            position=position,
+            start_date=datetime.now()
+        )
+        
+        assert holding.id == 1
+        assert holding.container == portfolio
+        assert holding.asset == company_share_portfolio
+        assert holding.company_share_portfolio == company_share_portfolio
+        
+        print("✅ Entity creation successful!")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Entity creation error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+if __name__ == "__main__":
+    print("🧪 Testing new CompanySharePortfolioPortfolioHolding entities...")
+    
+    success = True
+    success &= test_imports()
+    success &= test_entity_creation()
+    
+    if success:
+        print("🎉 All tests passed!")
+    else:
+        print("💥 Some tests failed!")
+    
+    exit(0 if success else 1)


### PR DESCRIPTION
Adds CompanySharePortfolioPortfolioHolding entity that allows portfolios to hold other portfolios as assets.

Implementation includes:
- Domain entity following DDD principles
- SQLAlchemy infrastructure model
- Proper relationships and inheritance
- Test file for validation

Resolves #564

Generated with [Claude Code](https://claude.ai/code)