### PR TITLE
feat: implement get_related_entities using SQLAlchemy inspect

### DIFF
--- a/src/infrastructure/repositories/local_repo/finance/holding/holding_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/holding/holding_repository.py
@@ -16,6 +16,7 @@ from src.domain.ports.finance.holding.holding_port import HoldingPort
 from src.infrastructure.repositories.local_repo.base_repository import BaseLocalRepository
 
 import logging
+from sqlalchemy import inspect
 
 logger = logging.getLogger(__name__)
 
@@ -345,6 +346,86 @@ class HoldingRepository(BaseLocalRepository, HoldingPort):
             
         except Exception as e:
             self.logger.error(f"Error creating position for holding {holding.id}: {str(e)}")
+
+    def get_related_entities(self, holding_id: int) -> List:
+        """
+        Get all entities related to a specific holding using SQLAlchemy inspect
+        to discover direct and indirect relationships.
+
+        Args:
+            holding_id: The holding ID to get related entities for
+
+        Returns:
+            List of related entities found through relationship inspection
+        """
+        try:
+            # Get the holding model to inspect its relationships
+            holding_model = self.session.query(HoldingModel).filter_by(id=holding_id).first()
+            if not holding_model:
+                logger.warning(f"Holding {holding_id} not found")
+                return []
+
+            related_entities = []
+            
+            # Use SQLAlchemy inspect to get relationship information
+            mapper = inspect(HoldingModel)
+            
+            # Process direct relationships (holding -> related entity)
+            for relationship_name, relationship in mapper.relationships.items():
+                try:
+                    # Get the related entity through the relationship
+                    related_value = getattr(holding_model, relationship_name, None)
+                    
+                    if related_value is not None:
+                        if hasattr(related_value, '__iter__') and not isinstance(related_value, str):
+                            # Collection relationship (one-to-many, many-to-many)
+                            for item in related_value:
+                                if item:
+                                    entity = self.mapper.to_entity(item) if hasattr(self.mapper, 'to_entity') else item
+                                    if entity:
+                                        related_entities.append(entity)
+                        else:
+                            # Single relationship (many-to-one, one-to-one)
+                            entity = self.mapper.to_entity(related_value) if hasattr(self.mapper, 'to_entity') else related_value
+                            if entity:
+                                related_entities.append(entity)
+                                
+                except Exception as rel_error:
+                    logger.debug(f"Could not access relationship {relationship_name}: {rel_error}")
+                    continue
+
+            # Process indirect relationships (entities that reference this holding)
+            # Look for entities that have foreign keys pointing to this holding
+            holding_table = mapper.mapped_table
+            
+            for table_name, table in holding_table.metadata.tables.items():
+                try:
+                    for column in table.columns:
+                        # Check if column is a foreign key to holding table
+                        if column.foreign_keys:
+                            for fk in column.foreign_keys:
+                                if fk.column.table.name == holding_table.name and str(fk.column.name) == 'id':
+                                    # Found a table that references holdings
+                                    # Query for entities that reference this holding
+                                    referencing_models = self.session.query(table).filter(
+                                        column == holding_id
+                                    ).all()
+                                    
+                                    for ref_model in referencing_models:
+                                        # Convert to entity if mapper available, otherwise use raw model
+                                        if hasattr(ref_model, '__table__'):
+                                            related_entities.append(ref_model)
+                                        
+                except Exception as indirect_error:
+                    logger.debug(f"Could not process indirect relationships for table {table_name}: {indirect_error}")
+                    continue
+
+            logger.info(f"Retrieved {len(related_entities)} related entities for holding {holding_id}")
+            return related_entities
+            
+        except Exception as e:
+            logger.error(f"Error retrieving related entities for holding {holding_id}: {str(e)}")
+            return []
 
     def get_related_position(self, holding_id: int):
         """

--- a/src/infrastructure/repositories/local_repo/finance/order/order_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/order/order_repository.py
@@ -9,6 +9,7 @@ import logging
 from typing import List, Optional
 from datetime import datetime
 from sqlalchemy.orm import Session
+from sqlalchemy import inspect
 
 from src.infrastructure.models.finance.order.order import OrderModel
 from src.domain.entities.finance.order.order import Order as OrderEntity
@@ -352,3 +353,83 @@ class OrderRepository(BaseLocalRepository, OrderPort):
         }
         
         return mapping.get(order_type, TransactionType.MARKET_ORDER)
+
+    def get_related_entities(self, order_id: int) -> List:
+        """
+        Get all entities related to a specific order using SQLAlchemy inspect
+        to discover direct and indirect relationships.
+
+        Args:
+            order_id: The order ID to get related entities for
+
+        Returns:
+            List of related entities found through relationship inspection
+        """
+        try:
+            # Get the order model to inspect its relationships
+            order_model = self.session.query(OrderModel).filter_by(id=order_id).first()
+            if not order_model:
+                logger.warning(f"Order {order_id} not found")
+                return []
+
+            related_entities = []
+            
+            # Use SQLAlchemy inspect to get relationship information
+            mapper = inspect(OrderModel)
+            
+            # Process direct relationships (order -> related entity)
+            for relationship_name, relationship in mapper.relationships.items():
+                try:
+                    # Get the related entity through the relationship
+                    related_value = getattr(order_model, relationship_name, None)
+                    
+                    if related_value is not None:
+                        if hasattr(related_value, '__iter__') and not isinstance(related_value, str):
+                            # Collection relationship (one-to-many, many-to-many)
+                            for item in related_value:
+                                if item:
+                                    entity = self.mapper.to_domain(item) if hasattr(self.mapper, 'to_domain') else item
+                                    if entity:
+                                        related_entities.append(entity)
+                        else:
+                            # Single relationship (many-to-one, one-to-one)
+                            entity = self.mapper.to_domain(related_value) if hasattr(self.mapper, 'to_domain') else related_value
+                            if entity:
+                                related_entities.append(entity)
+                                
+                except Exception as rel_error:
+                    logger.debug(f"Could not access relationship {relationship_name}: {rel_error}")
+                    continue
+
+            # Process indirect relationships (entities that reference this order)
+            # Look for entities that have foreign keys pointing to this order
+            order_table = mapper.mapped_table
+            
+            for table_name, table in order_table.metadata.tables.items():
+                try:
+                    for column in table.columns:
+                        # Check if column is a foreign key to order table
+                        if column.foreign_keys:
+                            for fk in column.foreign_keys:
+                                if fk.column.table.name == order_table.name and str(fk.column.name) == 'id':
+                                    # Found a table that references orders
+                                    # Query for entities that reference this order
+                                    referencing_models = self.session.query(table).filter(
+                                        column == order_id
+                                    ).all()
+                                    
+                                    for ref_model in referencing_models:
+                                        # Convert to entity if mapper available, otherwise use raw model
+                                        if hasattr(ref_model, '__table__'):
+                                            related_entities.append(ref_model)
+                                        
+                except Exception as indirect_error:
+                    logger.debug(f"Could not process indirect relationships for table {table_name}: {indirect_error}")
+                    continue
+
+            logger.info(f"Retrieved {len(related_entities)} related entities for order {order_id}")
+            return related_entities
+            
+        except Exception as e:
+            logger.error(f"Error retrieving related entities for order {order_id}: {str(e)}")
+            return []

--- a/src/infrastructure/repositories/local_repo/finance/portfolio/portfolio_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/portfolio/portfolio_repository.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Dict, Any
 from datetime import datetime, date
 from sqlalchemy.orm import Session
 from decimal import Decimal
+from sqlalchemy import inspect
 
 logger = logging.getLogger(__name__)
 
@@ -352,25 +353,82 @@ class PortfolioRepository(BaseLocalRepository, PortfolioPort):
 
     def get_related_entities(self, portfolio_id: int) -> List:
         """
-        Get all entities related to a specific portfolio (its holdings).
+        Get all entities related to a specific portfolio using SQLAlchemy inspect
+        to discover direct and indirect relationships.
 
         Args:
-            portfolio_id: The portfolio ID to get holdings for
+            portfolio_id: The portfolio ID to get related entities for
 
         Returns:
-            List of holding entities related to this portfolio
+            List of related entities found through relationship inspection
         """
         try:
-            from src.infrastructure.repositories.local_repo.finance.holding.holding_repository import HoldingRepository
+            # Get the portfolio model to inspect its relationships
+            portfolio_model = self.session.query(self.model_class).filter_by(id=portfolio_id).first()
+            if not portfolio_model:
+                logger.warning(f"Portfolio {portfolio_id} not found")
+                return []
+
+            related_entities = []
             
-            holding_repo = HoldingRepository(self.session, self.factory)
-            holdings = holding_repo.get_by_container_id(portfolio_id)
+            # Use SQLAlchemy inspect to get relationship information
+            mapper = inspect(self.model_class)
             
-            logger.info(f"Retrieved {len(holdings)} holdings for portfolio {portfolio_id}")
-            return holdings
+            # Process direct relationships (portfolio -> related entity)
+            for relationship_name, relationship in mapper.relationships.items():
+                try:
+                    # Get the related entity through the relationship
+                    related_value = getattr(portfolio_model, relationship_name, None)
+                    
+                    if related_value is not None:
+                        if hasattr(related_value, '__iter__') and not isinstance(related_value, str):
+                            # Collection relationship (one-to-many, many-to-many)
+                            for item in related_value:
+                                if item:
+                                    entity = self._to_entity(item) if hasattr(self, '_to_entity') else item
+                                    if entity:
+                                        related_entities.append(entity)
+                        else:
+                            # Single relationship (many-to-one, one-to-one)
+                            entity = self._to_entity(related_value) if hasattr(self, '_to_entity') else related_value
+                            if entity:
+                                related_entities.append(entity)
+                                
+                except Exception as rel_error:
+                    logger.debug(f"Could not access relationship {relationship_name}: {rel_error}")
+                    continue
+
+            # Process indirect relationships (entities that reference this portfolio)
+            # Look for entities that have foreign keys pointing to this portfolio
+            portfolio_table = mapper.mapped_table
+            
+            for table_name, table in portfolio_table.metadata.tables.items():
+                try:
+                    for column in table.columns:
+                        # Check if column is a foreign key to portfolio table
+                        if column.foreign_keys:
+                            for fk in column.foreign_keys:
+                                if fk.column.table.name == portfolio_table.name and str(fk.column.name) == 'id':
+                                    # Found a table that references portfolios
+                                    # Query for entities that reference this portfolio
+                                    referencing_models = self.session.query(table).filter(
+                                        column == portfolio_id
+                                    ).all()
+                                    
+                                    for ref_model in referencing_models:
+                                        # Convert to entity if mapper available, otherwise use raw model
+                                        if hasattr(ref_model, '__table__'):
+                                            related_entities.append(ref_model)
+                                        
+                except Exception as indirect_error:
+                    logger.debug(f"Could not process indirect relationships for table {table_name}: {indirect_error}")
+                    continue
+
+            logger.info(f"Retrieved {len(related_entities)} related entities for portfolio {portfolio_id}")
+            return related_entities
             
         except Exception as e:
-            logger.error(f"Error retrieving holdings for portfolio {portfolio_id}: {str(e)}")
+            logger.error(f"Error retrieving related entities for portfolio {portfolio_id}: {str(e)}")
             return []
 
     # Standard CRUD interface

--- a/src/infrastructure/repositories/local_repo/finance/transaction/transaction_repository.py
+++ b/src/infrastructure/repositories/local_repo/finance/transaction/transaction_repository.py
@@ -9,6 +9,7 @@ import logging
 from typing import List, Optional
 from datetime import datetime, date
 from sqlalchemy.orm import Session
+from sqlalchemy import inspect
 
 from src.infrastructure.models.finance.transaction.transaction import TransactionModel
 from src.domain.entities.finance.transaction.transaction import Transaction as TransactionEntity
@@ -338,3 +339,83 @@ class TransactionRepository(BaseLocalRepository, TransactionPort):
                 
         except Exception as e:
             logger.error(f"Error updating holding for transaction {transaction.id}: {str(e)}")
+
+    def get_related_entities(self, transaction_id: int) -> List:
+        """
+        Get all entities related to a specific transaction using SQLAlchemy inspect
+        to discover direct and indirect relationships.
+
+        Args:
+            transaction_id: The transaction ID to get related entities for
+
+        Returns:
+            List of related entities found through relationship inspection
+        """
+        try:
+            # Get the transaction model to inspect its relationships
+            transaction_model = self.session.query(TransactionModel).filter_by(id=transaction_id).first()
+            if not transaction_model:
+                logger.warning(f"Transaction {transaction_id} not found")
+                return []
+
+            related_entities = []
+            
+            # Use SQLAlchemy inspect to get relationship information
+            mapper = inspect(TransactionModel)
+            
+            # Process direct relationships (transaction -> related entity)
+            for relationship_name, relationship in mapper.relationships.items():
+                try:
+                    # Get the related entity through the relationship
+                    related_value = getattr(transaction_model, relationship_name, None)
+                    
+                    if related_value is not None:
+                        if hasattr(related_value, '__iter__') and not isinstance(related_value, str):
+                            # Collection relationship (one-to-many, many-to-many)
+                            for item in related_value:
+                                if item:
+                                    entity = self.mapper.to_domain(item) if hasattr(self.mapper, 'to_domain') else item
+                                    if entity:
+                                        related_entities.append(entity)
+                        else:
+                            # Single relationship (many-to-one, one-to-one)
+                            entity = self.mapper.to_domain(related_value) if hasattr(self.mapper, 'to_domain') else related_value
+                            if entity:
+                                related_entities.append(entity)
+                                
+                except Exception as rel_error:
+                    logger.debug(f"Could not access relationship {relationship_name}: {rel_error}")
+                    continue
+
+            # Process indirect relationships (entities that reference this transaction)
+            # Look for entities that have foreign keys pointing to this transaction
+            transaction_table = mapper.mapped_table
+            
+            for table_name, table in transaction_table.metadata.tables.items():
+                try:
+                    for column in table.columns:
+                        # Check if column is a foreign key to transaction table
+                        if column.foreign_keys:
+                            for fk in column.foreign_keys:
+                                if fk.column.table.name == transaction_table.name and str(fk.column.name) == 'id':
+                                    # Found a table that references transactions
+                                    # Query for entities that reference this transaction
+                                    referencing_models = self.session.query(table).filter(
+                                        column == transaction_id
+                                    ).all()
+                                    
+                                    for ref_model in referencing_models:
+                                        # Convert to entity if mapper available, otherwise use raw model
+                                        if hasattr(ref_model, '__table__'):
+                                            related_entities.append(ref_model)
+                                        
+                except Exception as indirect_error:
+                    logger.debug(f"Could not process indirect relationships for table {table_name}: {indirect_error}")
+                    continue
+
+            logger.info(f"Retrieved {len(related_entities)} related entities for transaction {transaction_id}")
+            return related_entities
+            
+        except Exception as e:
+            logger.error(f"Error retrieving related entities for transaction {transaction_id}: {str(e)}")
+            return []


### PR DESCRIPTION
Implements get_related_entities method in portfolio, holding, order, and transaction repositories using SQLAlchemy inspect to automatically discover direct and indirect relationships.

Closes #568

Generated with [Claude Code](https://claude.ai/code)